### PR TITLE
Add 2023 (post and preBPix) campaigns 

### DIFF
--- a/cmsdb/campaigns/run3_2023_postBPix_nano_tau_skim_v2/__init__.py
+++ b/cmsdb/campaigns/run3_2023_postBPix_nano_tau_skim_v2/__init__.py
@@ -1,0 +1,28 @@
+from order import Campaign
+#
+# campaign
+#
+
+campaign_run3_2023_postBPix_nano_tau_skim_v2 = Campaign(
+    name="run3_2023_postBPix_nano_tau_skim_v2",
+    id=20231401,  # run 3 year 2022 ver 12 #01 is just for separation between different configs
+    ecm=13.6,
+    bx=25,
+    aux={
+        "tier": "NanoAOD",
+        "year": 2022,
+        "version": 14,
+        "tag": "postBPix",
+        "run": 3,
+        "custom": {
+            "name": "run3_2023_postBPix_nano_tau_skim_v2",
+            "creator": "desy",
+            "location": "/eos/cms/store/group/phys_higgs/HLepRare/skim_2024_v2/Run3_2023BPix"
+        },
+    },
+)
+
+import cmsdb.campaigns.run3_2023_postBPix_nano_tau_skim_v2.ewk
+import cmsdb.campaigns.run3_2023_postBPix_nano_tau_skim_v2.data
+import cmsdb.campaigns.run3_2023_postBPix_nano_tau_skim_v2.top
+

--- a/cmsdb/campaigns/run3_2023_postBPix_nano_tau_skim_v2/__init__.py
+++ b/cmsdb/campaigns/run3_2023_postBPix_nano_tau_skim_v2/__init__.py
@@ -10,7 +10,7 @@ campaign_run3_2023_postBPix_nano_tau_skim_v2 = Campaign(
     bx=25,
     aux={
         "tier": "NanoAOD",
-        "year": 2022,
+        "year": 2023,
         "version": 14,
         "tag": "postBPix",
         "run": 3,

--- a/cmsdb/campaigns/run3_2023_postBPix_nano_tau_skim_v2/data.py
+++ b/cmsdb/campaigns/run3_2023_postBPix_nano_tau_skim_v2/data.py
@@ -20,7 +20,7 @@ cpn.add_dataset(
     processes=[procs.data_e],
     keys=['/EGamma0_Run2023D_v1', '/EGamma0_Run2023D_v2', '/EGamma1_Run2023D_v1', '/EGamma1_Run2023D_v2'],
     n_files=64 + 14 + 64 + 14,
-    n_events= 49635861 + 10741086 + 49626665 + 10743629, 
+    n_events= 105892646 + 22657211 + 105850543 + 22653287,
     aux={
         'era': 'D'
     }
@@ -34,7 +34,7 @@ cpn.add_dataset(
     processes=[procs.data_mu],
     keys=['/Muon0_Run2023D_v1', '/Muon0_Run2023D_v2', '/Muon1_Run2023D_v1', '/Muon1_Run2023D_v2'],
     n_files= 53 + 12 + 53 + 12,
-    n_events= 50726971 + 11041859 + 50772523 + 11045936,
+    n_events= 100211533 + 21462916 + 100281976 + 21463645,
     aux={
         'era': 'D'
     }
@@ -47,7 +47,7 @@ cpn.add_dataset(
     processes=[procs.data_tau],
     keys=['/Tau_Run2023D_v1', '/Tau_Run2023D_v2'],
     n_files=31 + 7,
-    n_events= 22751203 + 5089799,
+    n_events= 32092659 + 7246202,
     aux={
         'era': 'D',
     }

--- a/cmsdb/campaigns/run3_2023_postBPix_nano_tau_skim_v2/data.py
+++ b/cmsdb/campaigns/run3_2023_postBPix_nano_tau_skim_v2/data.py
@@ -1,0 +1,55 @@
+# coding: utf-8
+
+"""
+CMS datasets from the 2023 preBPix E data-taking campaign
+"""
+
+import cmsdb.processes as procs
+from cmsdb.campaigns.run3_2023_postBPix_nano_tau_skim_v2  import campaign_run3_2023_postBPix_nano_tau_skim_v2 as cpn
+
+
+
+"""
+CMS datasets from the 2023 preBPix data-taking campaign /eos/cms/store/group/phys_higgs/HLepRare/skim_2024_v2/Run3_2023/
+"""
+
+cpn.add_dataset(
+    name='data_e_D',
+    id=2212010,
+    is_data=True,
+    processes=[procs.data_e],
+    keys=['/EGamma0_Run2023D_v1', '/EGamma0_Run2023D_v2', '/EGamma1_Run2023D_v1', '/EGamma1_Run2023D_v2'],
+    n_files=64 + 14 + 64 + 14,
+    n_events= 49635861 + 10741086 + 49626665 + 10743629, 
+    aux={
+        'era': 'D'
+    }
+)
+
+
+cpn.add_dataset(
+    name='data_mu_D',
+    id=2212011,
+    is_data=True,
+    processes=[procs.data_mu],
+    keys=['/Muon0_Run2023D_v1', '/Muon0_Run2023D_v2', '/Muon1_Run2023D_v1', '/Muon1_Run2023D_v2'],
+    n_files= 53 + 12 + 53 + 12,
+    n_events= 50726971 + 11041859 + 50772523 + 11045936,
+    aux={
+        'era': 'D'
+    }
+)
+
+cpn.add_dataset(
+    name='data_tau_D',
+    id=2212012,
+    is_data=True,
+    processes=[procs.data_tau],
+    keys=['/Tau_Run2023D_v1', '/Tau_Run2023D_v2'],
+    n_files=31 + 7,
+    n_events= 22751203 + 5089799,
+    aux={
+        'era': 'D',
+    }
+)
+

--- a/cmsdb/campaigns/run3_2023_postBPix_nano_tau_skim_v2/ewk.py
+++ b/cmsdb/campaigns/run3_2023_postBPix_nano_tau_skim_v2/ewk.py
@@ -1,0 +1,388 @@
+# coding: utf-8
+
+"""
+Electroweak datasets for the 2022 pre-EE data-taking campaign
+"""
+
+from order import DatasetInfo
+
+import cmsdb.processes as procs
+from cmsdb.campaigns.run3_2023_postBPix_nano_tau_skim_v2  import campaign_run3_2023_postBPix_nano_tau_skim_v2 as cpn
+
+####################################################################################################
+#
+# Drell-Yan
+#
+####################################################################################################
+
+
+cpn.add_dataset(
+    name='dy_lep_madgraph', #DYto2L_M-50
+    id=2212013,
+    processes=[procs.dy_lep],
+    keys=['/DYto2L_M_50_madgraphMLM'],
+    n_files=68,
+    n_events=36636046,
+    aux=None
+)
+
+cpn.add_dataset(
+    name='wj_incl_madgraph',
+    id=414,
+    processes=[procs.wj],
+    keys=['/WtoLNu_madgraphMLM'],
+    n_files=51,
+    n_events=19010206,
+    aux=None,
+)
+
+cpn.add_dataset(
+    name='ww',
+    id=22120112,
+    processes=[procs.ww],
+    keys=['/WW'],
+    n_files=12,
+    n_events=6544933,
+    aux=None
+)
+
+cpn.add_dataset(
+    name='wz',
+    id=22120113,
+    processes=[procs.wz],
+    keys=['/WZ'],
+    n_files=6,
+    n_events=2942360,
+    aux=None
+)
+
+cpn.add_dataset(
+    name='zz',
+    id=22120114,
+    processes=[procs.zz],
+    keys=['/ZZ'],
+    n_files=1,
+    n_events=396965,
+    aux=None
+)
+
+
+# cpn.add_dataset(
+#     name="dataset_17",
+#     id=17,
+#     processes=[procs.process_17],
+#     keys=['DYto2TautoMuTauh_M_50_madgraphMLM'],
+#     n_files=4,
+#     n_events=2930759.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_18",
+#     id=18,
+#     processes=[procs.process_18],
+#     keys=['DYto2L_M_10to50_madgraphMLM'],
+#     n_files=67,
+#     n_events=160214290.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_19",
+#     id=19,
+#     processes=[procs.process_19],
+#     keys=['DYto2L_M_50_1J_madgraphMLM'],
+#     n_files=17,
+#     n_events=14855860.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_20",
+#     id=20,
+#     processes=[procs.process_20],
+#     keys=['DYto2L_M_50_2J_madgraphMLM'],
+#     n_files=20,
+#     n_events=14654880.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_21",
+#     id=21,
+#     processes=[procs.process_21],
+#     keys=['DYto2L_M_50_3J_madgraphMLM'],
+#     n_files=14,
+#     n_events=8672888.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_22",
+#     id=22,
+#     processes=[procs.process_22],
+#     keys=['DYto2L_M_50_4J_madgraphMLM'],
+#     n_files=7,
+#     n_events=3258128.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_43",
+#     id=43,
+#     processes=[procs.process_43],
+#     keys=['ZZto2L2Nu_powheg'],
+#     n_files=16,
+#     n_events=14521499.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_44",
+#     id=44,
+#     processes=[procs.process_44],
+#     keys=['ZZto2L2Nu_powheg_ext1'],
+#     n_files=13,
+#     n_events=14727726.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_45",
+#     id=45,
+#     processes=[procs.process_45],
+#     keys=['ZZto2L2Q_amcatnloFXFX'],
+#     n_files=4,
+#     n_events=1310582.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_46",
+#     id=46,
+#     processes=[procs.process_46],
+#     keys=['ZZto2L2Q_powheg'],
+#     n_files=16,
+#     n_events=14573574.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_47",
+#     id=47,
+#     processes=[procs.process_47],
+#     keys=['ZZto2L2Q_powheg_ext1'],
+#     n_files=17,
+#     n_events=14905382.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_48",
+#     id=48,
+#     processes=[procs.process_48],
+#     keys=['ZZto2Nu2Q_powheg'],
+#     n_files=2,
+#     n_events=2927750.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_49",
+#     id=49,
+#     processes=[procs.process_49],
+#     keys=['ZZto2Nu2Q_powheg_ext1'],
+#     n_files=2,
+#     n_events=2953837.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_50",
+#     id=50,
+#     processes=[procs.process_50],
+#     keys=['ZZto4L_powheg'],
+#     n_files=17,
+#     n_events=14481306.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_51",
+#     id=51,
+#     processes=[procs.process_51],
+#     keys=['ZZto4L_powheg_ext1'],
+#     n_files=18,
+#     n_events=14297032.0,
+# )
+
+
+
+# cpn.add_dataset(
+#     name="dataset_53",
+#     id=53,
+#     processes=[procs.process_53],
+#     keys=['WZto2L2Q_powheg'],
+#     n_files=5,
+#     n_events=4163435.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_54",
+#     id=54,
+#     processes=[procs.process_54],
+#     keys=['WZto2L2Q_powheg_ext1'],
+#     n_files=5,
+#     n_events=4269337.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_55",
+#     id=55,
+#     processes=[procs.process_55],
+#     keys=['WZto3LNu_amcatnloFXFX'],
+#     n_files=4,
+#     n_events=1906322.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_56",
+#     id=56,
+#     processes=[procs.process_56],
+#     keys=['WZto3LNu_powheg'],
+#     n_files=4,
+#     n_events=2791528.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_57",
+#     id=57,
+#     processes=[procs.process_57],
+#     keys=['WZtoL3Nu_amcatnloFXFX'],
+#     n_files=2,
+#     n_events=1128058.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_58",
+#     id=58,
+#     processes=[procs.process_58],
+#     keys=['WZtoLNu2Q_amcatnloFXFX'],
+#     n_files=4,
+#     n_events=1404272.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_59",
+#     id=59,
+#     processes=[procs.process_59],
+#     keys=['WZtoLNu2Q_powheg'],
+#     n_files=9,
+#     n_events=8896204.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_60",
+#     id=60,
+#     processes=[procs.process_60],
+#     keys=['WZtoLNu2Q_powheg_ext1'],
+#     n_files=10,
+#     n_events=8722878.0,
+# )
+
+
+
+# cpn.add_dataset(
+#     name="dataset_62",
+#     id=62,
+#     processes=[procs.process_62],
+#     keys=['WWto2L2Nu_powheg'],
+#     n_files=8,
+#     n_events=6133972.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_63",
+#     id=63,
+#     processes=[procs.process_63],
+#     keys=['WWto2L2Nu_powheg_ext1'],
+#     n_files=9,
+#     n_events=6598672.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_64",
+#     id=64,
+#     processes=[procs.process_64],
+#     keys=['WWto4Q_amcatnloFXFX'],
+#     n_files=9,
+#     n_events=6813648.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_65",
+#     id=65,
+#     processes=[procs.process_65],
+#     keys=['WWto4Q_powheg'],
+#     n_files=20,
+#     n_events=28172516.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_66",
+#     id=66,
+#     processes=[procs.process_66],
+#     keys=['WWto4Q_powheg_ext1'],
+#     n_files=38,
+#     n_events=28188069.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_67",
+#     id=67,
+#     processes=[procs.process_67],
+#     keys=['WWtoLNu2Q_amcatnloFXFX'],
+#     n_files=28,
+#     n_events=14248541.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_68",
+#     id=68,
+#     processes=[procs.process_68],
+#     keys=['WWtoLNu2Q_powheg'],
+#     n_files=29,
+#     n_events=27103682.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_69",
+#     id=69,
+#     processes=[procs.process_69],
+#     keys=['WWtoLNu2Q_powheg_ext1'],
+#     n_files=29,
+#     n_events=26557496.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_75",
+#     id=75,
+#     processes=[procs.process_75],
+#     keys=['WtoLNu_1J_madgraphMLM'],
+#     n_files=8,
+#     n_events=11896625.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_76",
+#     id=76,
+#     processes=[procs.process_76],
+#     keys=['WtoLNu_2J_madgraphMLM'],
+#     n_files=8,
+#     n_events=9283334.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_77",
+#     id=77,
+#     processes=[procs.process_77],
+#     keys=['WtoLNu_3J_madgraphMLM'],
+#     n_files=9,
+#     n_events=8221862.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_78",
+#     id=78,
+#     processes=[procs.process_78],
+#     keys=['WtoLNu_4J_madgraphMLM'],
+#     n_files=3,
+#     n_events=1463885.0,
+# )
+

--- a/cmsdb/campaigns/run3_2023_postBPix_nano_tau_skim_v2/ewk.py
+++ b/cmsdb/campaigns/run3_2023_postBPix_nano_tau_skim_v2/ewk.py
@@ -22,7 +22,7 @@ cpn.add_dataset(
     processes=[procs.dy_lep],
     keys=['/DYto2L_M_50_madgraphMLM'],
     n_files=68,
-    n_events=36636046,
+    n_events=69398459,
     aux=None
 )
 
@@ -32,7 +32,7 @@ cpn.add_dataset(
     processes=[procs.wj],
     keys=['/WtoLNu_madgraphMLM'],
     n_files=51,
-    n_events=19010206,
+    n_events=94639090,
     aux=None,
 )
 
@@ -42,7 +42,7 @@ cpn.add_dataset(
     processes=[procs.ww],
     keys=['/WW'],
     n_files=12,
-    n_events=6544933,
+    n_events=16545000,
     aux=None
 )
 
@@ -52,7 +52,7 @@ cpn.add_dataset(
     processes=[procs.wz],
     keys=['/WZ'],
     n_files=6,
-    n_events=2942360,
+    n_events=8379000,
     aux=None
 )
 
@@ -62,7 +62,7 @@ cpn.add_dataset(
     processes=[procs.zz],
     keys=['/ZZ'],
     n_files=1,
-    n_events=396965,
+    n_events=1254000,
     aux=None
 )
 

--- a/cmsdb/campaigns/run3_2023_postBPix_nano_tau_skim_v2/higgs.py
+++ b/cmsdb/campaigns/run3_2023_postBPix_nano_tau_skim_v2/higgs.py
@@ -1,0 +1,1246 @@
+# coding: utf-8
+
+"""
+Higgs datasets for the 2022preEE data-taking campaign
+"""
+
+from order import DatasetInfo
+
+import cmsdb.processes as procs
+from cmsdb.campaigns.run3_2022_preEE_nano_tau_skim_v2 import campaign_run3_2022_preEE_nano_tau_skim_v2 as cpn
+
+
+#
+# Single Higgs
+#
+
+####################################################################################################
+#
+# h_ggf
+#
+####################################################################################################
+
+# cpn.add_dataset(
+#     name="h_ggf_hbb_pt200toinf_powheg",
+#     id=14801316,
+#     processes=[procs.h_ggf_hbb_pt200toinf],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/GluGluHto2B_PT-200_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=29,
+#             n_events=59480,
+#         ),
+#         extension=DatasetInfo(
+#             keys=[
+#                 "/GluGluHto2B_PT-200_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=291,
+#             n_events=4324232,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="h_ggf_hcc_pt200toinf_powheg",
+#     id=14797543,
+#     processes=[procs.h_ggf_hcc_pt200toinf],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/GluGluHtoCC_PT-200_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=20,
+#             n_events=122144,
+#         ),
+#     ),
+# )
+cpn.add_dataset(
+    name="h_ggf_hgg_amcatnlo",
+    id=14805985,
+    processes=[procs.h_ggf_hgg],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHtoGG_M-125_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=27,
+            n_events=933797,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_ggf_hzz4l_powheg",
+    id=14796087,
+    processes=[procs.h_ggf_hzz4l],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHtoZZto4L_M-125_TuneCP5_13p6TeV_powheg2-JHUGenV752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=24,
+            n_events=486643,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_ggf_hzg_zll_powheg",
+    id=14797462,
+    processes=[procs.h_ggf_hzg_zll],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHtoZG_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=19,
+            n_events=55000,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/GluGluHtoZG_Zto2L_M-125_CP5TuneDown_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=2,
+            n_events=55000,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/GluGluHtoZG_Zto2L_M-125_CP5TuneUp_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=21,
+            n_events=54999,
+        ),
+    ),
+)
+# NOTE: there are also htt samples with *UncorrelatedDecay* in the DAS name. They are not considered here.
+cpn.add_dataset(
+    name="h_ggf_htt_powheg",
+    id=14805667,
+    processes=[procs.h_ggf_htt],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHToTauTau_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=14,
+            n_events=295722,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_ggf_hbb_powheg",
+    id=14876200,
+    processes=[procs.h_ggf_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHto2B_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=53,
+            n_events=4353624,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_ggf_hww2l2nu_powheg",
+    id=14849365,
+    processes=[procs.h_ggf_hww2l2nu],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-jhugen752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=60,
+            n_events=1494981,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/GluGluHto2Wto2L2Nu_M-125_TuneCP5Down_13p6TeV_powheg-jhugen752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=55,
+            n_events=1494981,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/GluGluHto2Wto2L2Nu_M-125_TuneCP5Up_13p6TeV_powheg-jhugen752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=59,
+            n_events=1497196,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_ggf_hzz4nu_powheg",
+    id=14849342,
+    processes=[procs.h_ggf_hzz4nu],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHto2Zto4Nu_PT-150_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=34,
+            n_events=1014208,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_ggf_hcc_powheg",
+    id=14877479,
+    processes=[procs.h_ggf_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHto2C_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=61,
+            n_events=4371062,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_ggf_htt_amcatnlo",
+    id=14849328,
+    processes=[procs.h_ggf_htt],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHto2Tau_M-125_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=29,
+            n_events=1038456,
+        ),
+    ),
+)
+# cpn.add_dataset(
+#     name="h_ggf_hcc_pt200toinf_powheg",
+#     id=14852276,
+#     processes=[procs.h_ggf_hcc_pt200toinf],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/GluGluHto2C_PT-200_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=319,
+#             n_events=4322480,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="h_ggf_hee_amcatnlo",
+#     id=14947996,
+#     processes=[procs.h_ggf_hee],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/GluGluHto2E_M-125_TuneCP5_13p6TeV_amcatnloFxFx-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=65,
+#             n_events=881432,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="h_ggf_hzz4l_ew0_powheg",
+#     id=14950668,
+#     processes=[procs.h_ggf_hzz4l_ew0],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/GluGluHtoZZto4L_ew0_M-125_TuneCP5_13p6TeV_powheg-jhugen-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=20,
+#             n_events=100000,
+#         ),
+#     ),
+# )
+cpn.add_dataset(
+    name="h_ggf_hmm_powheg",
+    id=14868421,
+    processes=[procs.h_ggf_hmm],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHto2Mu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=21,
+            n_events=200000,
+        ),
+    ),
+)
+
+####################################################################################################
+#
+# h_vbf
+#
+####################################################################################################
+
+cpn.add_dataset(
+    name="h_vbf_hzg_zll_powheg",
+    id=14798046,
+    processes=[procs.h_vbf_hzg_zll],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/VBFHtoZG_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=5,
+            n_events=12000,
+        ),
+        with_dipole_recoil=DatasetInfo(
+            keys=[
+                "/VBFHtoZG_Zto2L_M-125_TuneCP5_withDipoleRecoil_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=4,
+            n_events=96465,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/VBFHtoZG_Zto2L_M-125_CP5TuneUp_withDipoleRecoil_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=5,
+            n_events=98582,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/VBFHtoZG_Zto2L_M-125_CP5TuneDown_withDipoleRecoil_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=5,
+            n_events=96480,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_vbf_hww2l2nu_powheg",
+    id=14849334,
+    processes=[procs.h_vbf_hww2l2nu],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/VBFHto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-jhugen752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=43,
+            n_events=1497840,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/VBFHto2Wto2L2Nu_M-125_TuneCP5Up_13p6TeV_powheg-jhugen752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=56,
+            n_events=1498588,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/VBFHto2Wto2L2Nu_M-125_TuneCP5Down_13p6TeV_powheg-jhugen752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=58,
+            n_events=1497840,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_vbf_hzz4nu_powheg",
+    id=14849329,
+    processes=[procs.h_vbf_hzz4nu],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/VBFHto2Zto4Nu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=30,
+            n_events=500000,
+        ),
+    ),
+)
+# NOTE: this sample includes the *UncorrelatedDecay* tag. No htt dataset without this tag has been found on 07.06.2024
+cpn.add_dataset(
+    name="h_vbf_htt_powheg",
+    id=14926213,
+    processes=[procs.h_vbf_htt],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/VBFHTo2TauUncorrelatedDecay_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=13,
+            n_events=100000,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_vbf_hgg_amcatnlo",
+    id=14885189,
+    processes=[procs.h_vbf_hgg],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/VBFHtoGG_M-125_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=15,
+            n_events=314360,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_vbf_hcc_powheg",
+    id=14853086,
+    processes=[procs.h_vbf_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/VBFHto2C_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=119,
+            n_events=4348092,
+        ),
+    ),
+)
+# cpn.add_dataset(
+#     name="h_vbf_hcc_powheg",
+#     id=14788422,
+#     processes=[procs.h_vbf_hcc],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/VBFHToCC_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-FlatPU0to70_130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=1,
+#             n_events=300000,
+#         ),
+#     ),
+# )
+cpn.add_dataset(
+    name="h_vbf_hbb_powheg",
+    id=14870810,
+    processes=[procs.h_vbf_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/VBFHto2B_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=33,
+            n_events=3330700,
+        ),
+        dipole_recoil_on=DatasetInfo(
+            keys=[
+                "/VBFHto2B_M-125_dipoleRecoilOn_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=31,
+            n_events=948700,
+        ),
+    ),
+)
+
+####################################################################################################
+#
+# zh
+#
+####################################################################################################
+
+cpn.add_dataset(
+    name="zh_zqq_hbb_powheg",
+    id=14805167,
+    processes=[procs.zh_zqq_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZH_Hto2B_Zto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=19,
+            n_events=1144560,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/ZH_Hto2B_Zto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=65,
+            n_events=3177722,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_hzg_powheg",
+    id=14794187,
+    processes=[procs.zh_hzg],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZH_HtoZG_ZtoAll_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=46,
+            n_events=124384,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_zll_hbb_powheg",
+    id=14805378,
+    processes=[procs.zh_zll_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZH_Hto2B_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=34,
+            n_events=599100,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/ZH_Hto2B_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=57,
+            n_events=4339792,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_zll_hcc_powheg",
+    id=14800392,
+    processes=[procs.zh_zll_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZH_Hto2C_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=27,
+            n_events=799380,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/ZH_Hto2C_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=45,
+            n_events=4153800,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_zqq_powheg",
+    id=14849422,
+    processes=[procs.zh_zqq],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZHto2Zto4Nu_Zto2Q_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=70,
+            n_events=497369,
+        ),
+    ),
+)
+# NOTE: this sample includes the *UncorrelatedDecay* tag. No htt dataset without this tag has been found on 07.06.2024
+cpn.add_dataset(
+    name="zh_htt_powheg",
+    id=14927154,
+    processes=[procs.zh_htt],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZHto2TauUncorrelatedDecay_M-125_CP5_13p6TeV_powheg-minnlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=22,
+            n_events=28752,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_hww2l2nu_powheg",
+    id=14918311,
+    processes=[procs.zh_hww2l2nu],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZH_ZtoAll_Hto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-minlo-HZJ-jhugenv752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=53,
+            n_events=963869,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_hzg_zll_powheg",
+    id=14885110,
+    processes=[procs.zh_hzg_zll],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZH_ZtoAll_HtoZGto2LG_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=52,
+            n_events=124660,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/ZH_ZtoAll_HtoZGto2LG_M-125_CP5TuneUp_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=51,
+            n_events=124656,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/ZH_ZtoAll_HtoZGto2LG_M-125_CP5TuneDown_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=38,
+            n_events=124659,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_zqq_hcc_powheg",
+    id=14868489,
+    processes=[procs.zh_zqq_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZH_Hto2C_Zto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=64,
+            n_events=3101694,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_hmm_powheg",
+    id=14863423,
+    processes=[procs.zh_hmm],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZH_Hto2Mu_ZtoAll_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=35,
+            n_events=196974,
+        ),
+    ),
+)
+
+####################################################################################################
+#
+# zh_gg
+#
+####################################################################################################
+
+cpn.add_dataset(
+    name="zh_gg_zqq_hbb_powheg",
+    id=14804331,
+    processes=[procs.zh_gg_zqq_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2B_Zto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=21,
+            n_events=578672,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2B_Zto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=59,
+            n_events=3782022,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_gg_zll_hbb_powheg",
+    id=14803231,
+    processes=[procs.zh_gg_zll_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2B_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=23,
+            n_events=582250,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2B_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=41,
+            n_events=3780820,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_gg_znunu_hbb_powheg",
+    id=14805533,
+    processes=[procs.zh_gg_znunu_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2B_Zto2Nu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=16,
+            n_events=581016,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2B_Zto2Nu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=39,
+            n_events=3784521,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_gg_zll_hcc_powheg",
+    id=14803676,
+    processes=[procs.zh_gg_zll_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2C_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=41,
+            n_events=773402,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2C_Zto2Nu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=38,
+            n_events=3588800,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_gg_znunu_hcc_powheg",
+    id=14846449,
+    processes=[procs.zh_gg_znunu_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2C_Zto2Nu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=29,
+            n_events=797924,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2C_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=39,
+            n_events=3593320,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_gg_zqq_hcc_powheg",
+    id=14853067,
+    processes=[procs.zh_gg_zqq_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2C_Zto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=114,
+            n_events=4391804,
+        ),
+    ),
+)
+
+####################################################################################################
+#
+# WminusH
+#
+####################################################################################################
+
+cpn.add_dataset(
+    name="wmh_hzz4l_powheg",
+    id=14793663,
+    processes=[procs.wmh_hzz4l],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2Zto4L_M-125_TuneCP5_13p6TeV_powheg2-minlo-HWJ-JHUGenV752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=19,
+            n_events=491969,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wmh_wlnu_hbb_powheg",
+    id=14805882,
+    processes=[procs.wmh_wlnu_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2B_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=21,
+            n_events=590044,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2B_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=169,
+            n_events=4399854,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wmh_wqq_hbb_powheg",
+    id=14801338,
+    processes=[procs.wmh_wqq_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2B_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=22,
+            n_events=1147965,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2B_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=223,
+            n_events=3153199,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wmh_wlnu_hcc_powheg",
+    id=14804815,
+    processes=[procs.wmh_wlnu_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2C_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=33,
+            n_events=732400,
+        ),
+    ),
+)
+# NOTE: this sample includes the *UncorrelatedDecay* tag. No htt dataset without this tag has been found on 07.06.2024
+cpn.add_dataset(
+    name="wmh_powheg",
+    id=14926126,
+    processes=[procs.wmh],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusHTo2TauUncorrelatedDecay_M-125_TuneCP5_13p6TeV_powheg-minnlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=12,
+            n_events=30000,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wmh_wqq_hcc_powheg",
+    id=14852474,
+    processes=[procs.wmh_wqq_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2C_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=321,
+            n_events=4357249,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2C_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=147,
+            n_events=4200000,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wmh_wqq_hzz4nu_powheg",
+    id=14849469,
+    processes=[procs.wmh_wqq_hzz4nu],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusHto2Zto4Nu_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=26,
+            n_events=497364,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wmh_hzg_zll_powheg",
+    id=14826664,
+    processes=[procs.wmh_hzg_zll],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusH_HtoZG_WtoAll_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=18,
+            n_events=53961,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/WminusH_HtoZG_WtoAll_Zto2L_M-125_CP5TuneUp_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=12,
+            n_events=70000,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/WminusH_HtoZG_WtoAll_Zto2L_M-125_CP5TuneDown_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=16,
+            n_events=69801,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wmh_hmm_powheg",
+    id=14856644,
+    processes=[procs.wmh_hmm],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2Mu_WtoAll_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=5,
+            n_events=120000,
+        ),
+    ),
+)
+
+####################################################################################################
+#
+# WplusH
+#
+####################################################################################################
+
+cpn.add_dataset(
+    name="wph_htt_powheg",
+    id=14925460,
+    processes=[procs.wph_htt],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusHTo2TauUncorrelatedDecay_M-125_TuneCP5_13p6TeV_powheg-minnlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=14,
+            n_events=30000,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_wqq_hbb_powheg",
+    id=14810156,
+    processes=[procs.wph_wqq_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2B_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=18,
+            n_events=1199214,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2B_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=147,
+            n_events=3179822,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_wlnu_hbb_powheg",
+    id=14804043,
+    processes=[procs.wph_wlnu_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2B_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=22,
+            n_events=565746,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2B_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=159,
+            n_events=4206261,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_wqq_hcc_powheg",
+    id=14852349,
+    processes=[procs.wph_wqq_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2C_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=271,
+            n_events=4369883,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_wlnu_hcc_powheg",
+    id=14795238,
+    processes=[procs.wph_wlnu_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2C_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=62,
+            n_events=754430,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2C_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=155,
+            n_events=4200000,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_hmm_powheg",
+    id=14868497,
+    processes=[procs.wph_hmm],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2Mu_WtoAll_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=26,
+            n_events=118804,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_hzz4l_powheg",
+    id=14810120,
+    processes=[procs.wph_hzz4l],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2Zto4L_M-125_TuneCP5_13p6TeV_powheg2-minlo-HWJ-JHUGenV752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=17,
+            n_events=492605,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_hzg_powheg",
+    id=14798660,
+    processes=[procs.wph_hzg],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusH_HtoZG_WtoAll_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=17,
+            n_events=38162,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/WplusH_HtoZG_WtoAll_Zto2L_M-125_CP5TuneDown_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=24,
+            n_events=39616,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/WplusH_HtoZG_WtoAll_Zto2L_M-125_CP5TuneUp_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=19,
+            n_events=39997,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_hzg_zll_powheg",
+    id=14792521,
+    processes=[procs.wph_hzg_zll],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusH_HtoZG_WtoAll_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=16,
+            n_events=156824,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_wqq_hzz4nu_powheg",
+    id=14849415,
+    processes=[procs.wph_wqq_hzz4nu],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusHto2Zto4Nu_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=28,
+            n_events=495938,
+        ),
+    ),
+)
+
+
+####################################################################################################
+#
+# ttH
+#
+####################################################################################################
+
+# cpn.add_dataset(
+#     name="tth_hzz_powheg",
+#     id=14793299,
+#     processes=[procs.tth_hzz],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/TTH_Hto2Z_M-125_4LFilter_TuneCP5_13p6TeV_powheg2-JHUGenV752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=20,
+#             n_events=96720,
+#         ),
+#     ),
+# )
+cpn.add_dataset(
+    name="tth_hzz_powheg",
+    id=14952169,
+    processes=[procs.tth_hzz],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTH_Hto2Z_4LFilter_M-125_TuneCP5_13p6TeV_powheg-jhugenv752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=7,
+            n_events=95869,
+        ),
+    ),
+)
+# cpn.add_dataset(
+#     name="tth_hnonbb_1j_amcatnlo",
+#     id=14852673,
+#     processes=[procs.tth_hnonbb_1j],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/TTHtoNon2B-1Jets_M-125_TuneCP5_13p6TeV_amcatnloFXFX-madspin-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=165,
+#             n_events=6303497,
+#         ),
+#     ),
+# )
+cpn.add_dataset(
+    name="tth_hnonbb_powheg",
+    id=14849153,
+    processes=[procs.tth_hnonbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTHtoNon2B_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v4/NANOAODSIM",  # noqa
+            ],
+            n_files=46,
+            n_events=3846525,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="tth_hcc_powheg",
+    id=14870558,
+    processes=[procs.tth_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTHto2C_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=37,
+            n_events=3184328,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="tth_hbb_powheg",
+    id=14857767,
+    processes=[procs.tth_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTHto2B_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=45,
+            n_events=3177628,
+        ),
+    ),
+)
+# cpn.add_dataset(
+#     name="tth_hbb_powheg",
+#     id=14870504,
+#     processes=[procs.tth_hbb],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/TTH_Hto2B_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+#             ],
+#             n_files=43,
+#             n_events=2989710,
+#         ),
+#     ),
+# )
+cpn.add_dataset(
+    name="tth_hmm_powheg",
+    id=14868415,
+    processes=[procs.tth_hmm],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTH_Hto2Mu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=28,
+            n_events=197248,
+        ),
+    ),
+)
+
+####################################################################################################
+#
+# ttVH
+#
+####################################################################################################
+
+cpn.add_dataset(
+    name="ttzh_madgraph",
+    id=14861662,
+    processes=[procs.ttz],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTZH_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=43,
+            n_events=798996,
+        ),
+    ),
+)
+
+cpn.add_dataset(
+    name="ttwh_madgraph",
+    id=14860507,
+    processes=[procs.ttwh],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTWH_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=25,
+            n_events=790196,
+        ),
+    ),
+)

--- a/cmsdb/campaigns/run3_2023_postBPix_nano_tau_skim_v2/signal.py
+++ b/cmsdb/campaigns/run3_2023_postBPix_nano_tau_skim_v2/signal.py
@@ -1,0 +1,545 @@
+# coding: utf-8
+
+"""
+CMS datasets from the 2022 post-EE data-taking campaign
+"""
+
+import cmsdb.processes as procs
+from cmsdb.campaigns.run3_2022_preEE_nano_tau_skim_v2 import campaign_run3_2022_preEE_nano_tau_skim_v2 as cpn
+
+cpn.add_dataset(
+    name='glugluhto2tau_uncorrelateddecay_unfiltered',
+    id=11100,
+    is_data=True,
+    processes=[procs.data_glugluhto2tau],
+    keys=['/GluGluHTo2Tau_UncorrelatedDecay_UnFiltered'],
+    n_files=1,
+    n_events=310379,
+)
+
+
+# cpn.add_dataset(
+#     name="signal",
+#     id=11100,
+#     processes=[procs.h_ggf_tautau],
+#     keys=['/GluGluHToTauTau_M125'],
+#     n_files=1,
+#     n_events=295692,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-1000_2HDM-II'],
+#     id=69,
+#     processes=[procs.process_69],
+#     keys=['GluGluHto2Tau_M-1000_2HDM-II'],
+#     n_files=1,
+#     n_events=446596,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-100_2HDM-II'],
+#     id=70,
+#     processes=[procs.h_ggf_tautau],
+#     keys=['/GluGluHto2Tau_M-100_2HDM-II'],
+#     n_files=1,
+#     n_events=449942,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-105_2HDM-II'],
+#     id=71,
+#     processes=[procs.process_71],
+#     keys=['GluGluHto2Tau_M-105_2HDM-II'],
+#     n_files=1,
+#     n_events=448536,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-1100_2HDM-II'],
+#     id=72,
+#     processes=[procs.process_72],
+#     keys=['GluGluHto2Tau_M-1100_2HDM-II'],
+#     n_files=1,
+#     n_events=447987,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-110_2HDM-II'],
+#     id=73,
+#     processes=[procs.process_73],
+#     keys=['GluGluHto2Tau_M-110_2HDM-II'],
+#     n_files=1,
+#     n_events=449958,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-115_2HDM-II'],
+#     id=74,
+#     processes=[procs.process_74],
+#     keys=['GluGluHto2Tau_M-115_2HDM-II'],
+#     n_files=1,
+#     n_events=447160,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-1200_2HDM-II'],
+#     id=75,
+#     processes=[procs.h_ggf_tautau],
+#     keys=['/GluGluHto2Tau_M-1200_2HDM-II'],
+#     n_files=1,
+#     n_events=447983,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-120_2HDM-II'],
+#     id=76,
+#     processes=[procs.process_76],
+#     keys=['GluGluHto2Tau_M-120_2HDM-II'],
+#     n_files=1,
+#     n_events=449175,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-125_2HDM-II'],
+#     id=77,
+#     processes=[procs.h_ggf_tautau],
+#     keys=['GluGluHto2Tau_M-125_2HDM-II'],
+#     n_files=1,
+#     n_events=447825,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-130_2HDM-II'],
+#     id=78,
+#     processes=[procs.process_78],
+#     keys=['GluGluHto2Tau_M-130_2HDM-II'],
+#     n_files=1,
+#     n_events=449968,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-135_2HDM-II'],
+#     id=79,
+#     processes=[procs.process_79],
+#     keys=['GluGluHto2Tau_M-135_2HDM-II'],
+#     n_files=1,
+#     n_events=449970,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-1400_2HDM-II'],
+#     id=80,
+#     processes=[procs.process_80],
+#     keys=['GluGluHto2Tau_M-1400_2HDM-II'],
+#     n_files=1,
+#     n_events=446050,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-140_2HDM-II'],
+#     id=81,
+#     processes=[procs.process_81],
+#     keys=['GluGluHto2Tau_M-140_2HDM-II'],
+#     n_files=1,
+#     n_events=449962,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-1600_2HDM-II'],
+#     id=82,
+#     processes=[procs.process_82],
+#     keys=['GluGluHto2Tau_M-1600_2HDM-II'],
+#     n_files=1,
+#     n_events=448004,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-160_2HDM-II'],
+#     id=83,
+#     processes=[procs.process_83],
+#     keys=['GluGluHto2Tau_M-160_2HDM-II'],
+#     n_files=1,
+#     n_events=449972,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-1800_2HDM-II'],
+#     id=84,
+#     processes=[procs.process_84],
+#     keys=['GluGluHto2Tau_M-1800_2HDM-II'],
+#     n_files=1,
+#     n_events=448684,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-180_2HDM-II'],
+#     id=85,
+#     processes=[procs.process_85],
+#     keys=['GluGluHto2Tau_M-180_2HDM-II'],
+#     n_files=1,
+#     n_events=449279,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-2000_2HDM-II'],
+#     id=86,
+#     processes=[procs.process_86],
+#     keys=['GluGluHto2Tau_M-2000_2HDM-II'],
+#     n_files=1,
+#     n_events=446753,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-200_2HDM-II'],
+#     id=87,
+#     processes=[procs.process_87],
+#     keys=['GluGluHto2Tau_M-200_2HDM-II'],
+#     n_files=1,
+#     n_events=448584,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-2300_2HDM-II'],
+#     id=88,
+#     processes=[procs.process_88],
+#     keys=['GluGluHto2Tau_M-2300_2HDM-II'],
+#     n_files=1,
+#     n_events=449309,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-250_2HDM-II'],
+#     id=89,
+#     processes=[procs.process_89],
+#     keys=['GluGluHto2Tau_M-250_2HDM-II'],
+#     n_files=1,
+#     n_events=448594,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-2600_2HDM-II'],
+#     id=90,
+#     processes=[procs.process_90],
+#     keys=['GluGluHto2Tau_M-2600_2HDM-II'],
+#     n_files=1,
+#     n_events=449332,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-2900_2HDM-II'],
+#     id=91,
+#     processes=[procs.process_91],
+#     keys=['GluGluHto2Tau_M-2900_2HDM-II'],
+#     n_files=1,
+#     n_events=446066,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-300_2HDM-II'],
+#     id=92,
+#     processes=[procs.process_92],
+#     keys=['GluGluHto2Tau_M-300_2HDM-II'],
+#     n_files=1,
+#     n_events=448598,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-3200_2HDM-II'],
+#     id=93,
+#     processes=[procs.process_93],
+#     keys=['GluGluHto2Tau_M-3200_2HDM-II'],
+#     n_files=1,
+#     n_events=449932,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-3500_2HDM-II'],
+#     id=94,
+#     processes=[procs.process_94],
+#     keys=['GluGluHto2Tau_M-3500_2HDM-II'],
+#     n_files=1,
+#     n_events=449908,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-350_2HDM-II'],
+#     id=95,
+#     processes=[procs.process_95],
+#     keys=['GluGluHto2Tau_M-350_2HDM-II'],
+#     n_files=1,
+#     n_events=447891,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-400_2HDM-II'],
+#     id=96,
+#     processes=[procs.process_96],
+#     keys=['GluGluHto2Tau_M-400_2HDM-II'],
+#     n_files=1,
+#     n_events=449301,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-450_2HDM-II'],
+#     id=97,
+#     processes=[procs.process_97],
+#     keys=['GluGluHto2Tau_M-450_2HDM-II'],
+#     n_files=1,
+#     n_events=449992,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-500_2HDM-II'],
+#     id=98,
+#     processes=[procs.process_98],
+#     keys=['GluGluHto2Tau_M-500_2HDM-II'],
+#     n_files=1,
+#     n_events=449988,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-600_2HDM-II'],
+#     id=99,
+#     processes=[procs.process_99],
+#     keys=['GluGluHto2Tau_M-600_2HDM-II'],
+#     n_files=1,
+#     n_events=449300,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-60_2HDM-II'],
+#     id=100,
+#     processes=[procs.process_100],
+#     keys=['GluGluHto2Tau_M-60_2HDM-II'],
+#     n_files=1,
+#     n_events=447803,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-65_2HDM-II'],
+#     id=101,
+#     processes=[procs.process_101],
+#     keys=['GluGluHto2Tau_M-65_2HDM-II'],
+#     n_files=1,
+#     n_events=448504,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-700_2HDM-II'],
+#     id=102,
+#     processes=[procs.process_102],
+#     keys=['GluGluHto2Tau_M-700_2HDM-II'],
+#     n_files=1,
+#     n_events=449994,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-70_2HDM-II'],
+#     id=103,
+#     processes=[procs.process_103],
+#     keys=['GluGluHto2Tau_M-70_2HDM-II'],
+#     n_files=1,
+#     n_events=448500,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-75_2HDM-II'],
+#     id=104,
+#     processes=[procs.process_104],
+#     keys=['GluGluHto2Tau_M-75_2HDM-II'],
+#     n_files=1,
+#     n_events=449940,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-800_2HDM-II'],
+#     id=105,
+#     processes=[procs.process_105],
+#     keys=['GluGluHto2Tau_M-800_2HDM-II'],
+#     n_files=1,
+#     n_events=448646,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-80_2HDM-II'],
+#     id=106,
+#     processes=[procs.process_106],
+#     keys=['GluGluHto2Tau_M-80_2HDM-II'],
+#     n_files=1,
+#     n_events=448532,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-85_2HDM-II'],
+#     id=107,
+#     processes=[procs.process_107],
+#     keys=['GluGluHto2Tau_M-85_2HDM-II'],
+#     n_files=1,
+#     n_events=448516,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-900_2HDM-II'],
+#     id=108,
+#     processes=[procs.process_108],
+#     keys=['GluGluHto2Tau_M-900_2HDM-II'],
+#     n_files=1,
+#     n_events=448622,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-90_2HDM-II'],
+#     id=109,
+#     processes=[procs.process_109],
+#     keys=['GluGluHto2Tau_M-90_2HDM-II'],
+#     n_files=1,
+#     n_events=448516,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-95_2HDM-II'],
+#     id=110,
+#     processes=[procs.process_110],
+#     keys=['GluGluHto2Tau_M-95_2HDM-II'],
+#     n_files=1,
+#     n_events=447820,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+# cpn.add_dataset(
+#     name=['VBFHToTauTau_M125'],
+#     id=370,
+#     processes=[procs.process_370],
+#     keys=['VBFHToTauTau_M125'],
+#     n_files=1,
+#     n_events=298955,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )

--- a/cmsdb/campaigns/run3_2023_postBPix_nano_tau_skim_v2/top.py
+++ b/cmsdb/campaigns/run3_2023_postBPix_nano_tau_skim_v2/top.py
@@ -14,7 +14,7 @@ cpn.add_dataset(
     processes=[procs.st_tchannel_t],
     keys=['/ST_t_channel_top_4f_InclusiveDecays'],
     n_files=3,
-    n_events=1115420,
+    n_events=2954000,
     aux=None
 )
 
@@ -25,7 +25,7 @@ cpn.add_dataset(
     processes=[procs.st_tchannel_tbar],
     keys=['/ST_t_channel_antitop_4f_InclusiveDecays'],
     n_files=2,
-    n_events=568985,
+    n_events=1488000,
     aux=None
 )
 
@@ -35,7 +35,7 @@ cpn.add_dataset(
     processes=[procs.st_twchannel_t_sl],
     keys=['/ST_tW_top_LNu2Q'],
     n_files=9,
-    n_events=3877916,
+    n_events=4943378,
     aux=None
 )
 
@@ -45,7 +45,7 @@ cpn.add_dataset(
     processes=[procs.st_twchannel_t_dl],
     keys=['/ST_tW_top_2L2Nu'],
     n_files=5,
-    n_events=2211653,
+    n_events=2479000,
     aux=None
 )
 
@@ -56,7 +56,7 @@ cpn.add_dataset(
     processes=[procs.st_twchannel_t_fh],
     keys=['/ST_tW_top_4Q'],
     n_files=5,
-    n_events=1498513,
+    n_events=3934000,
     aux=None
 )
 
@@ -66,7 +66,7 @@ cpn.add_dataset(
     processes=[procs.st_twchannel_tbar_sl],
     keys=['/ST_tW_antitop_LNu2Q'],
     n_files=10,
-    n_events=4040377,
+    n_events=5146630,
     aux=None
 )
 
@@ -76,7 +76,7 @@ cpn.add_dataset(
     processes=[procs.st_twchannel_tbar_dl],
     keys=['/ST_tW_antitop_2L2Nu'],
     n_files=5,
-    n_events=2219055,
+    n_events=2488000,
     aux=None
 )
 
@@ -86,7 +86,7 @@ cpn.add_dataset(
     processes=[procs.st_twchannel_tbar_fh],
     keys=['/ST_tW_antitop_4Q'],
     n_files=5,
-    n_events=1515010,
+    n_events=3976000,
     aux=None
 )
 cpn.add_dataset(
@@ -95,7 +95,7 @@ cpn.add_dataset(
     processes=[procs.st_schannel_t_lep],
     keys=['/ST_s_channel_top_4f_leptonDecays'],
     n_files=2,
-    n_events=716943,
+    n_events=1288000,
 )
 cpn.add_dataset(
     name="st_schannel_tbar_lep",
@@ -103,7 +103,7 @@ cpn.add_dataset(
     processes=[procs.st_schannel_tbar_lep],
     keys=['/ST_s_channel_antitop_4f_leptonDecays'],
     n_files = 1,
-    n_events = 436998,
+    n_events = 784000,
 )
 ### TT SAMPLES ###
 
@@ -113,7 +113,7 @@ cpn.add_dataset(
     processes=[procs.tt_sl],
     keys=['/TTtoLNu2Q'],
     n_files= 169,
-    n_events= 63088768,
+    n_events= 76670000,
     aux=None
 )
 
@@ -123,7 +123,7 @@ cpn.add_dataset(
     processes=[procs.tt_dl],
     keys=['/TTto2L2Nu'],
     n_files=56,
-    n_events=22680638,
+    n_events=24556000,
     aux=None
 )
 
@@ -133,7 +133,7 @@ cpn.add_dataset(
     processes=[procs.tt_fh],
     keys=['/TTto4Q'],
     n_files=72,
-    n_events=23044294,
+    n_events=52849000,
     aux=None
 )
 

--- a/cmsdb/campaigns/run3_2023_postBPix_nano_tau_skim_v2/top.py
+++ b/cmsdb/campaigns/run3_2023_postBPix_nano_tau_skim_v2/top.py
@@ -1,0 +1,177 @@
+
+"""
+Top quark datasets for the 2022 pre-EE data-taking campaign
+"""
+
+import cmsdb.processes as procs
+from cmsdb.campaigns.run3_2023_postBPix_nano_tau_skim_v2  import campaign_run3_2023_postBPix_nano_tau_skim_v2 as cpn
+
+### SINGLE TOP ###
+#TBbarQ
+cpn.add_dataset(
+    name='st_tchannel_t',
+    id=22120118,
+    processes=[procs.st_tchannel_t],
+    keys=['/ST_t_channel_top_4f_InclusiveDecays'],
+    n_files=3,
+    n_events=1115420,
+    aux=None
+)
+
+#TbarBQ_t
+cpn.add_dataset(
+    name='st_tchannel_tbar',
+    id=22120119,
+    processes=[procs.st_tchannel_tbar],
+    keys=['/ST_t_channel_antitop_4f_InclusiveDecays'],
+    n_files=2,
+    n_events=568985,
+    aux=None
+)
+
+cpn.add_dataset(
+    name='st_twchannel_t_sl',
+    id=22120120,
+    processes=[procs.st_twchannel_t_sl],
+    keys=['/ST_tW_top_LNu2Q'],
+    n_files=9,
+    n_events=3877916,
+    aux=None
+)
+
+cpn.add_dataset(
+    name='st_twchannel_t_dl',
+    id=22120121,
+    processes=[procs.st_twchannel_t_dl],
+    keys=['/ST_tW_top_2L2Nu'],
+    n_files=5,
+    n_events=2211653,
+    aux=None
+)
+
+
+cpn.add_dataset(
+    name='st_twchannel_t_fh',
+    id=22120122,
+    processes=[procs.st_twchannel_t_fh],
+    keys=['/ST_tW_top_4Q'],
+    n_files=5,
+    n_events=1498513,
+    aux=None
+)
+
+cpn.add_dataset(
+    name='st_twchannel_tbar_sl',
+    id=22120123,
+    processes=[procs.st_twchannel_tbar_sl],
+    keys=['/ST_tW_antitop_LNu2Q'],
+    n_files=10,
+    n_events=4040377,
+    aux=None
+)
+
+cpn.add_dataset(
+    name='st_twchannel_tbar_dl',
+    id=22120124,
+    processes=[procs.st_twchannel_tbar_dl],
+    keys=['/ST_tW_antitop_2L2Nu'],
+    n_files=5,
+    n_events=2219055,
+    aux=None
+)
+
+cpn.add_dataset(
+    name='st_twchannel_tbar_fh',
+    id=22120125,
+    processes=[procs.st_twchannel_tbar_fh],
+    keys=['/ST_tW_antitop_4Q'],
+    n_files=5,
+    n_events=1515010,
+    aux=None
+)
+cpn.add_dataset(
+    name="st_schannel_t_lep",
+    id=22120126,
+    processes=[procs.st_schannel_t_lep],
+    keys=['/ST_s_channel_top_4f_leptonDecays'],
+    n_files=2,
+    n_events=716943,
+)
+cpn.add_dataset(
+    name="st_schannel_tbar_lep",
+    id=22120127,
+    processes=[procs.st_schannel_tbar_lep],
+    keys=['/ST_s_channel_antitop_4f_leptonDecays'],
+    n_files = 1,
+    n_events = 436998,
+)
+### TT SAMPLES ###
+
+cpn.add_dataset(
+    name='tt_sl',
+    id=22120115,
+    processes=[procs.tt_sl],
+    keys=['/TTtoLNu2Q'],
+    n_files= 169,
+    n_events= 63088768,
+    aux=None
+)
+
+cpn.add_dataset(
+    name='tt_dl',
+    id=22120116,
+    processes=[procs.tt_dl],
+    keys=['/TTto2L2Nu'],
+    n_files=56,
+    n_events=22680638,
+    aux=None
+)
+
+cpn.add_dataset(
+    name='tt_fh',
+    id=22120117,
+    processes=[procs.tt_fh],
+    keys=['/TTto4Q'],
+    n_files=72,
+    n_events=23044294,
+    aux=None
+)
+
+
+
+# cpn.add_dataset(
+#     name="dataset_40",
+#     id=40,
+#     processes=[procs.process_40],
+#     keys=['ST_t_channel_antitop_4f_InclusiveDecays'],
+#     n_files=2,
+#     n_events=1325389.0,
+# )
+
+
+
+# cpn.add_dataset(
+#     name="dataset_70",
+#     id=70,
+#     processes=[procs.process_70],
+#     keys=['TT'],
+#     n_files=14,
+#     n_events=7398738.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_71",
+#     id=71,
+#     processes=[procs.process_71],
+#     keys=['TT_ext1'],
+#     n_files=13,
+#     n_events=7301650.0,
+# )
+
+
+
+
+
+
+
+

--- a/cmsdb/campaigns/run3_2023_preBPix_nano_tau_skim_v2/__init__.py
+++ b/cmsdb/campaigns/run3_2023_preBPix_nano_tau_skim_v2/__init__.py
@@ -10,7 +10,7 @@ campaign_run3_2023_preBPix_nano_tau_skim_v2 = Campaign(
     bx=25,
     aux={
         "tier": "NanoAOD",
-        "year": 2022,
+        "year": 2023,
         "version": 14,
         "tag": "preBPix",
         "run": 3,

--- a/cmsdb/campaigns/run3_2023_preBPix_nano_tau_skim_v2/__init__.py
+++ b/cmsdb/campaigns/run3_2023_preBPix_nano_tau_skim_v2/__init__.py
@@ -1,0 +1,28 @@
+from order import Campaign
+#
+# campaign
+#
+
+campaign_run3_2023_preBPix_nano_tau_skim_v2 = Campaign(
+    name="run3_2023_preBPix_nano_tau_skim_v2",
+    id=20231401,  # run 3 year 2022 ver 12 #01 is just for separation between different configs
+    ecm=13.6,
+    bx=25,
+    aux={
+        "tier": "NanoAOD",
+        "year": 2022,
+        "version": 14,
+        "tag": "preBPix",
+        "run": 3,
+        "custom": {
+            "name": "run3_2023_preBPix_nano_tau_skim_v2",
+            "creator": "desy",
+            "location": "/eos/cms/store/group/phys_higgs/HLepRare/skim_2024_v2/Run3_2023"
+        },
+    },
+)
+
+import cmsdb.campaigns.run3_2023_preBPix_nano_tau_skim_v2.ewk
+import cmsdb.campaigns.run3_2023_preBPix_nano_tau_skim_v2.data
+import cmsdb.campaigns.run3_2023_preBPix_nano_tau_skim_v2.top
+

--- a/cmsdb/campaigns/run3_2023_preBPix_nano_tau_skim_v2/data.py
+++ b/cmsdb/campaigns/run3_2023_preBPix_nano_tau_skim_v2/data.py
@@ -1,0 +1,53 @@
+# coding: utf-8
+
+"""
+CMS datasets from the 2023 preBPix E data-taking campaign
+"""
+
+import cmsdb.processes as procs
+from cmsdb.campaigns.run3_2023_preBPix_nano_tau_skim_v2  import campaign_run3_2023_preBPix_nano_tau_skim_v2 as cpn
+
+"""
+CMS datasets from the 2023 preBPix data-taking campaign /eos/cms/store/group/phys_higgs/HLepRare/skim_2024_v2/Run3_2023/
+"""
+
+cpn.add_dataset(
+    name='data_e_C',
+    id=2212010,
+    is_data=True,
+    processes=[procs.data_e],
+    keys=['/EGamma0_Run2023C_v1', '/EGamma0_Run2023C_v2', '/EGamma0_Run2023C_v3', '/EGamma0_Run2023C_v4','/EGamma1_Run2023C_v1', '/EGamma1_Run2023C_v2', '/EGamma1_Run2023C_v3', '/EGamma1_Run2023C_v4'],
+    n_files=38 + 11 + 13 + 94 + 38 + 11 + 13 + 94,
+    n_events=30038670 + 7890231 + 9817005 + 72118251 + 30010181 + 7891642 + 9818391 + 72080022,
+    aux={
+        'era': 'C'
+    }
+)
+
+
+cpn.add_dataset(
+    name='data_mu_C',
+    id=2212011,
+    is_data=True,
+    processes=[procs.data_mu],
+    keys=['/Muon0_Run2023C_v1', '/Muon0_Run2023C_v2', '/Muon0_Run2023C_v3', '/Muon0_Run2023C_v4','/Muon1_Run2023C_v1', '/Muon1_Run2023C_v2', '/Muon1_Run2023C_v3', '/Muon1_Run2023C_v4'],
+    n_files=27 + 9 + 11 + 75 + 27 + 9 + 11 + 75,
+    n_events= 25754131 + 8049224 + 9788396 + 71162252 + 25717768 + 8050781 + 9787601 + 71111717,
+    aux={
+        'era': 'C'
+    }
+)
+
+cpn.add_dataset(
+    name='data_tau_C',
+    id=2212012,
+    is_data=True,
+    processes=[procs.data_tau],
+    keys=['/Tau_Run2023C_v1', '/Tau_Run2023C_v2', '/Tau_Run2023C_v3', '/Tau_Run2023C_v4'],
+    n_files=15 + 5 + 7 + 45,
+    n_events=10255817 + 3607056 + 4585815 + 32314548,
+    aux={
+        'era': 'C',
+    }
+)
+

--- a/cmsdb/campaigns/run3_2023_preBPix_nano_tau_skim_v2/data.py
+++ b/cmsdb/campaigns/run3_2023_preBPix_nano_tau_skim_v2/data.py
@@ -18,7 +18,7 @@ cpn.add_dataset(
     processes=[procs.data_e],
     keys=['/EGamma0_Run2023C_v1', '/EGamma0_Run2023C_v2', '/EGamma0_Run2023C_v3', '/EGamma1_Run2023C_v1', '/EGamma1_Run2023C_v2', '/EGamma1_Run2023C_v3'],
     n_files=38 + 11 + 13 + 38 + 11 + 13,
-    n_events=30038670 + 7890231 + 9817005 + 30010181 + 7891642 + 9818391,
+    n_events= 67598081 + 17233307 + 21993048 + 67530273 + 17230822 + 21987586, 
     aux={
         'era': 'C',
         'jec_era': 'Cv123'
@@ -32,7 +32,7 @@ cpn.add_dataset(
     processes=[procs.data_e],
     keys=['/EGamma0_Run2023C_v4', '/EGamma1_Run2023C_v4'],
     n_files=94 + 94,
-    n_events= 72118251 + 72080022,
+    n_events= 160108119 + 159997174,
     aux={
         'era': 'C',
         'jec_era': 'Cv4'
@@ -46,7 +46,7 @@ cpn.add_dataset(
     processes=[procs.data_mu],
     keys=['/Muon0_Run2023C_v1', '/Muon0_Run2023C_v2', '/Muon0_Run2023C_v3', '/Muon1_Run2023C_v1', '/Muon1_Run2023C_v2', '/Muon1_Run2023C_v3'],
     n_files=27 + 9 + 11 + 27 + 9 + 11,
-    n_events= 25754131 + 8049224 + 9788396 + 25717768 + 8050781 + 9787601 ,
+    n_events= 54715896 + 17063451 + 20015377 + 54621922 + 17059895 + 20010429,
     aux={
         'era': 'C',
         'jec_era': 'Cv123'
@@ -61,7 +61,7 @@ cpn.add_dataset(
     processes=[procs.data_mu],
     keys=['/Muon0_Run2023C_v4', '/Muon1_Run2023C_v4'],
     n_files= 75 + 75,
-    n_events= 71162252 + 71111717,
+    n_events= 138943783 + 138834244,
     aux={
         'era': 'C',
         'jec_era': 'Cv4'
@@ -76,7 +76,7 @@ cpn.add_dataset(
     processes=[procs.data_tau],
     keys=['/Tau_Run2023C_v1', '/Tau_Run2023C_v2', '/Tau_Run2023C_v3'],
     n_files=15 + 5 + 7,
-    n_events=10255817 + 3607056 + 4585815,
+    n_events= 14484171 + 5178955 + 6470602,
     aux={
         'era': 'C',
         'jec_era': 'Cv123'
@@ -92,7 +92,7 @@ cpn.add_dataset(
     processes=[procs.data_tau],
     keys=['/Tau_Run2023C_v4'],
     n_files= 45,
-    n_events= 32314548,
+    n_events= 45176805,
     aux={
         'era': 'C',
         'jec_era': 'Cv4'

--- a/cmsdb/campaigns/run3_2023_preBPix_nano_tau_skim_v2/data.py
+++ b/cmsdb/campaigns/run3_2023_preBPix_nano_tau_skim_v2/data.py
@@ -12,42 +12,90 @@ CMS datasets from the 2023 preBPix data-taking campaign /eos/cms/store/group/phy
 """
 
 cpn.add_dataset(
-    name='data_e_C',
+    name='data_e_Cv123',
     id=2212010,
     is_data=True,
     processes=[procs.data_e],
-    keys=['/EGamma0_Run2023C_v1', '/EGamma0_Run2023C_v2', '/EGamma0_Run2023C_v3', '/EGamma0_Run2023C_v4','/EGamma1_Run2023C_v1', '/EGamma1_Run2023C_v2', '/EGamma1_Run2023C_v3', '/EGamma1_Run2023C_v4'],
-    n_files=38 + 11 + 13 + 94 + 38 + 11 + 13 + 94,
-    n_events=30038670 + 7890231 + 9817005 + 72118251 + 30010181 + 7891642 + 9818391 + 72080022,
+    keys=['/EGamma0_Run2023C_v1', '/EGamma0_Run2023C_v2', '/EGamma0_Run2023C_v3', '/EGamma1_Run2023C_v1', '/EGamma1_Run2023C_v2', '/EGamma1_Run2023C_v3'],
+    n_files=38 + 11 + 13 + 38 + 11 + 13,
+    n_events=30038670 + 7890231 + 9817005 + 30010181 + 7891642 + 9818391,
     aux={
-        'era': 'C'
+        'era': 'C',
+        'jec_era': 'Cv123'
     }
 )
 
+cpn.add_dataset(
+    name='data_e_Cv4',
+    id=221201001,
+    is_data=True,
+    processes=[procs.data_e],
+    keys=['/EGamma0_Run2023C_v4', '/EGamma1_Run2023C_v4'],
+    n_files=94 + 94,
+    n_events= 72118251 + 72080022,
+    aux={
+        'era': 'C',
+        'jec_era': 'Cv4'
+    }
+)
 
 cpn.add_dataset(
-    name='data_mu_C',
+    name='data_mu_Cv123',
     id=2212011,
     is_data=True,
     processes=[procs.data_mu],
-    keys=['/Muon0_Run2023C_v1', '/Muon0_Run2023C_v2', '/Muon0_Run2023C_v3', '/Muon0_Run2023C_v4','/Muon1_Run2023C_v1', '/Muon1_Run2023C_v2', '/Muon1_Run2023C_v3', '/Muon1_Run2023C_v4'],
-    n_files=27 + 9 + 11 + 75 + 27 + 9 + 11 + 75,
-    n_events= 25754131 + 8049224 + 9788396 + 71162252 + 25717768 + 8050781 + 9787601 + 71111717,
+    keys=['/Muon0_Run2023C_v1', '/Muon0_Run2023C_v2', '/Muon0_Run2023C_v3', '/Muon1_Run2023C_v1', '/Muon1_Run2023C_v2', '/Muon1_Run2023C_v3'],
+    n_files=27 + 9 + 11 + 27 + 9 + 11,
+    n_events= 25754131 + 8049224 + 9788396 + 25717768 + 8050781 + 9787601 ,
     aux={
-        'era': 'C'
+        'era': 'C',
+        'jec_era': 'Cv123'
     }
 )
 
+
 cpn.add_dataset(
-    name='data_tau_C',
+    name='data_mu_Cv4',
+    id=221201101,
+    is_data=True,
+    processes=[procs.data_mu],
+    keys=['/Muon0_Run2023C_v4', '/Muon1_Run2023C_v4'],
+    n_files= 75 + 75,
+    n_events= 71162252 + 71111717,
+    aux={
+        'era': 'C',
+        'jec_era': 'Cv4'
+    }
+)
+
+
+cpn.add_dataset(
+    name='data_tau_Cv123',
     id=2212012,
     is_data=True,
     processes=[procs.data_tau],
-    keys=['/Tau_Run2023C_v1', '/Tau_Run2023C_v2', '/Tau_Run2023C_v3', '/Tau_Run2023C_v4'],
-    n_files=15 + 5 + 7 + 45,
-    n_events=10255817 + 3607056 + 4585815 + 32314548,
+    keys=['/Tau_Run2023C_v1', '/Tau_Run2023C_v2', '/Tau_Run2023C_v3'],
+    n_files=15 + 5 + 7,
+    n_events=10255817 + 3607056 + 4585815,
     aux={
         'era': 'C',
+        'jec_era': 'Cv123'
+    }
+)
+
+
+
+cpn.add_dataset(
+    name='data_tau_Cv4',
+    id=221201201,
+    is_data=True,
+    processes=[procs.data_tau],
+    keys=['/Tau_Run2023C_v4'],
+    n_files= 45,
+    n_events= 32314548,
+    aux={
+        'era': 'C',
+        'jec_era': 'Cv4'
     }
 )
 

--- a/cmsdb/campaigns/run3_2023_preBPix_nano_tau_skim_v2/ewk.py
+++ b/cmsdb/campaigns/run3_2023_preBPix_nano_tau_skim_v2/ewk.py
@@ -1,0 +1,389 @@
+# coding: utf-8
+
+"""
+Electroweak datasets for the 2022 pre-EE data-taking campaign
+"""
+
+from order import DatasetInfo
+
+import cmsdb.processes as procs
+from cmsdb.campaigns.run3_2023_preBPix_nano_tau_skim_v2  import campaign_run3_2023_preBPix_nano_tau_skim_v2 as cpn
+
+
+####################################################################################################
+#
+# Drell-Yan
+#
+####################################################################################################
+
+
+cpn.add_dataset(
+    name='dy_lep_madgraph', #DYto2L_M-50
+    id=2212013,
+    processes=[procs.dy_lep],
+    keys=['/DYto2L_M_50_madgraphMLM'],
+    n_files=128,
+    n_events=69079056,
+    aux=None
+)
+
+cpn.add_dataset(
+    name='wj_incl_madgraph',
+    id=414,
+    processes=[procs.wj],
+    keys=['/WtoLNu_madgraphMLM'],
+    n_files=104,
+    n_events=38471437,
+    aux=None,
+)
+
+cpn.add_dataset(
+    name='ww',
+    id=22120112,
+    processes=[procs.ww],
+    keys=['/WW'],
+    n_files=24,
+    n_events=13287890,
+    aux=None
+)
+
+cpn.add_dataset(
+    name='wz',
+    id=22120113,
+    processes=[procs.wz],
+    keys=['/WZ'],
+    n_files=12,
+    n_events=5903382,
+    aux=None
+)
+
+cpn.add_dataset(
+    name='zz',
+    id=22120114,
+    processes=[procs.zz],
+    keys=['/ZZ'],
+    n_files=2,
+    n_events=799062,
+    aux=None
+)
+
+
+# cpn.add_dataset(
+#     name="dataset_17",
+#     id=17,
+#     processes=[procs.process_17],
+#     keys=['DYto2TautoMuTauh_M_50_madgraphMLM'],
+#     n_files=4,
+#     n_events=2930759.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_18",
+#     id=18,
+#     processes=[procs.process_18],
+#     keys=['DYto2L_M_10to50_madgraphMLM'],
+#     n_files=67,
+#     n_events=160214290.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_19",
+#     id=19,
+#     processes=[procs.process_19],
+#     keys=['DYto2L_M_50_1J_madgraphMLM'],
+#     n_files=17,
+#     n_events=14855860.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_20",
+#     id=20,
+#     processes=[procs.process_20],
+#     keys=['DYto2L_M_50_2J_madgraphMLM'],
+#     n_files=20,
+#     n_events=14654880.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_21",
+#     id=21,
+#     processes=[procs.process_21],
+#     keys=['DYto2L_M_50_3J_madgraphMLM'],
+#     n_files=14,
+#     n_events=8672888.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_22",
+#     id=22,
+#     processes=[procs.process_22],
+#     keys=['DYto2L_M_50_4J_madgraphMLM'],
+#     n_files=7,
+#     n_events=3258128.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_43",
+#     id=43,
+#     processes=[procs.process_43],
+#     keys=['ZZto2L2Nu_powheg'],
+#     n_files=16,
+#     n_events=14521499.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_44",
+#     id=44,
+#     processes=[procs.process_44],
+#     keys=['ZZto2L2Nu_powheg_ext1'],
+#     n_files=13,
+#     n_events=14727726.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_45",
+#     id=45,
+#     processes=[procs.process_45],
+#     keys=['ZZto2L2Q_amcatnloFXFX'],
+#     n_files=4,
+#     n_events=1310582.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_46",
+#     id=46,
+#     processes=[procs.process_46],
+#     keys=['ZZto2L2Q_powheg'],
+#     n_files=16,
+#     n_events=14573574.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_47",
+#     id=47,
+#     processes=[procs.process_47],
+#     keys=['ZZto2L2Q_powheg_ext1'],
+#     n_files=17,
+#     n_events=14905382.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_48",
+#     id=48,
+#     processes=[procs.process_48],
+#     keys=['ZZto2Nu2Q_powheg'],
+#     n_files=2,
+#     n_events=2927750.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_49",
+#     id=49,
+#     processes=[procs.process_49],
+#     keys=['ZZto2Nu2Q_powheg_ext1'],
+#     n_files=2,
+#     n_events=2953837.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_50",
+#     id=50,
+#     processes=[procs.process_50],
+#     keys=['ZZto4L_powheg'],
+#     n_files=17,
+#     n_events=14481306.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_51",
+#     id=51,
+#     processes=[procs.process_51],
+#     keys=['ZZto4L_powheg_ext1'],
+#     n_files=18,
+#     n_events=14297032.0,
+# )
+
+
+
+# cpn.add_dataset(
+#     name="dataset_53",
+#     id=53,
+#     processes=[procs.process_53],
+#     keys=['WZto2L2Q_powheg'],
+#     n_files=5,
+#     n_events=4163435.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_54",
+#     id=54,
+#     processes=[procs.process_54],
+#     keys=['WZto2L2Q_powheg_ext1'],
+#     n_files=5,
+#     n_events=4269337.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_55",
+#     id=55,
+#     processes=[procs.process_55],
+#     keys=['WZto3LNu_amcatnloFXFX'],
+#     n_files=4,
+#     n_events=1906322.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_56",
+#     id=56,
+#     processes=[procs.process_56],
+#     keys=['WZto3LNu_powheg'],
+#     n_files=4,
+#     n_events=2791528.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_57",
+#     id=57,
+#     processes=[procs.process_57],
+#     keys=['WZtoL3Nu_amcatnloFXFX'],
+#     n_files=2,
+#     n_events=1128058.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_58",
+#     id=58,
+#     processes=[procs.process_58],
+#     keys=['WZtoLNu2Q_amcatnloFXFX'],
+#     n_files=4,
+#     n_events=1404272.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_59",
+#     id=59,
+#     processes=[procs.process_59],
+#     keys=['WZtoLNu2Q_powheg'],
+#     n_files=9,
+#     n_events=8896204.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_60",
+#     id=60,
+#     processes=[procs.process_60],
+#     keys=['WZtoLNu2Q_powheg_ext1'],
+#     n_files=10,
+#     n_events=8722878.0,
+# )
+
+
+
+# cpn.add_dataset(
+#     name="dataset_62",
+#     id=62,
+#     processes=[procs.process_62],
+#     keys=['WWto2L2Nu_powheg'],
+#     n_files=8,
+#     n_events=6133972.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_63",
+#     id=63,
+#     processes=[procs.process_63],
+#     keys=['WWto2L2Nu_powheg_ext1'],
+#     n_files=9,
+#     n_events=6598672.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_64",
+#     id=64,
+#     processes=[procs.process_64],
+#     keys=['WWto4Q_amcatnloFXFX'],
+#     n_files=9,
+#     n_events=6813648.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_65",
+#     id=65,
+#     processes=[procs.process_65],
+#     keys=['WWto4Q_powheg'],
+#     n_files=20,
+#     n_events=28172516.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_66",
+#     id=66,
+#     processes=[procs.process_66],
+#     keys=['WWto4Q_powheg_ext1'],
+#     n_files=38,
+#     n_events=28188069.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_67",
+#     id=67,
+#     processes=[procs.process_67],
+#     keys=['WWtoLNu2Q_amcatnloFXFX'],
+#     n_files=28,
+#     n_events=14248541.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_68",
+#     id=68,
+#     processes=[procs.process_68],
+#     keys=['WWtoLNu2Q_powheg'],
+#     n_files=29,
+#     n_events=27103682.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_69",
+#     id=69,
+#     processes=[procs.process_69],
+#     keys=['WWtoLNu2Q_powheg_ext1'],
+#     n_files=29,
+#     n_events=26557496.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_75",
+#     id=75,
+#     processes=[procs.process_75],
+#     keys=['WtoLNu_1J_madgraphMLM'],
+#     n_files=8,
+#     n_events=11896625.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_76",
+#     id=76,
+#     processes=[procs.process_76],
+#     keys=['WtoLNu_2J_madgraphMLM'],
+#     n_files=8,
+#     n_events=9283334.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_77",
+#     id=77,
+#     processes=[procs.process_77],
+#     keys=['WtoLNu_3J_madgraphMLM'],
+#     n_files=9,
+#     n_events=8221862.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_78",
+#     id=78,
+#     processes=[procs.process_78],
+#     keys=['WtoLNu_4J_madgraphMLM'],
+#     n_files=3,
+#     n_events=1463885.0,
+# )
+

--- a/cmsdb/campaigns/run3_2023_preBPix_nano_tau_skim_v2/ewk.py
+++ b/cmsdb/campaigns/run3_2023_preBPix_nano_tau_skim_v2/ewk.py
@@ -23,7 +23,7 @@ cpn.add_dataset(
     processes=[procs.dy_lep],
     keys=['/DYto2L_M_50_madgraphMLM'],
     n_files=128,
-    n_events=69079056,
+    n_events=130559088,
     aux=None
 )
 
@@ -33,7 +33,7 @@ cpn.add_dataset(
     processes=[procs.wj],
     keys=['/WtoLNu_madgraphMLM'],
     n_files=104,
-    n_events=38471437,
+    n_events=191075090,
     aux=None,
 )
 
@@ -43,7 +43,7 @@ cpn.add_dataset(
     processes=[procs.ww],
     keys=['/WW'],
     n_files=24,
-    n_events=13287890,
+    n_events=33507000,
     aux=None
 )
 
@@ -53,7 +53,7 @@ cpn.add_dataset(
     processes=[procs.wz],
     keys=['/WZ'],
     n_files=12,
-    n_events=5903382,
+    n_events=16770000,
     aux=None
 )
 
@@ -63,7 +63,7 @@ cpn.add_dataset(
     processes=[procs.zz],
     keys=['/ZZ'],
     n_files=2,
-    n_events=799062,
+    n_events=2517000,
     aux=None
 )
 

--- a/cmsdb/campaigns/run3_2023_preBPix_nano_tau_skim_v2/higgs.py
+++ b/cmsdb/campaigns/run3_2023_preBPix_nano_tau_skim_v2/higgs.py
@@ -1,0 +1,1246 @@
+# coding: utf-8
+
+"""
+Higgs datasets for the 2022preEE data-taking campaign
+"""
+
+from order import DatasetInfo
+
+import cmsdb.processes as procs
+from cmsdb.campaigns.run3_2022_preEE_nano_tau_skim_v2 import campaign_run3_2022_preEE_nano_tau_skim_v2 as cpn
+
+
+#
+# Single Higgs
+#
+
+####################################################################################################
+#
+# h_ggf
+#
+####################################################################################################
+
+# cpn.add_dataset(
+#     name="h_ggf_hbb_pt200toinf_powheg",
+#     id=14801316,
+#     processes=[procs.h_ggf_hbb_pt200toinf],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/GluGluHto2B_PT-200_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=29,
+#             n_events=59480,
+#         ),
+#         extension=DatasetInfo(
+#             keys=[
+#                 "/GluGluHto2B_PT-200_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=291,
+#             n_events=4324232,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="h_ggf_hcc_pt200toinf_powheg",
+#     id=14797543,
+#     processes=[procs.h_ggf_hcc_pt200toinf],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/GluGluHtoCC_PT-200_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=20,
+#             n_events=122144,
+#         ),
+#     ),
+# )
+cpn.add_dataset(
+    name="h_ggf_hgg_amcatnlo",
+    id=14805985,
+    processes=[procs.h_ggf_hgg],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHtoGG_M-125_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=27,
+            n_events=933797,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_ggf_hzz4l_powheg",
+    id=14796087,
+    processes=[procs.h_ggf_hzz4l],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHtoZZto4L_M-125_TuneCP5_13p6TeV_powheg2-JHUGenV752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=24,
+            n_events=486643,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_ggf_hzg_zll_powheg",
+    id=14797462,
+    processes=[procs.h_ggf_hzg_zll],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHtoZG_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=19,
+            n_events=55000,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/GluGluHtoZG_Zto2L_M-125_CP5TuneDown_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=2,
+            n_events=55000,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/GluGluHtoZG_Zto2L_M-125_CP5TuneUp_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=21,
+            n_events=54999,
+        ),
+    ),
+)
+# NOTE: there are also htt samples with *UncorrelatedDecay* in the DAS name. They are not considered here.
+cpn.add_dataset(
+    name="h_ggf_htt_powheg",
+    id=14805667,
+    processes=[procs.h_ggf_htt],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHToTauTau_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=14,
+            n_events=295722,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_ggf_hbb_powheg",
+    id=14876200,
+    processes=[procs.h_ggf_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHto2B_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=53,
+            n_events=4353624,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_ggf_hww2l2nu_powheg",
+    id=14849365,
+    processes=[procs.h_ggf_hww2l2nu],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-jhugen752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=60,
+            n_events=1494981,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/GluGluHto2Wto2L2Nu_M-125_TuneCP5Down_13p6TeV_powheg-jhugen752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=55,
+            n_events=1494981,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/GluGluHto2Wto2L2Nu_M-125_TuneCP5Up_13p6TeV_powheg-jhugen752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=59,
+            n_events=1497196,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_ggf_hzz4nu_powheg",
+    id=14849342,
+    processes=[procs.h_ggf_hzz4nu],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHto2Zto4Nu_PT-150_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=34,
+            n_events=1014208,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_ggf_hcc_powheg",
+    id=14877479,
+    processes=[procs.h_ggf_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHto2C_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=61,
+            n_events=4371062,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_ggf_htt_amcatnlo",
+    id=14849328,
+    processes=[procs.h_ggf_htt],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHto2Tau_M-125_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=29,
+            n_events=1038456,
+        ),
+    ),
+)
+# cpn.add_dataset(
+#     name="h_ggf_hcc_pt200toinf_powheg",
+#     id=14852276,
+#     processes=[procs.h_ggf_hcc_pt200toinf],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/GluGluHto2C_PT-200_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=319,
+#             n_events=4322480,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="h_ggf_hee_amcatnlo",
+#     id=14947996,
+#     processes=[procs.h_ggf_hee],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/GluGluHto2E_M-125_TuneCP5_13p6TeV_amcatnloFxFx-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=65,
+#             n_events=881432,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="h_ggf_hzz4l_ew0_powheg",
+#     id=14950668,
+#     processes=[procs.h_ggf_hzz4l_ew0],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/GluGluHtoZZto4L_ew0_M-125_TuneCP5_13p6TeV_powheg-jhugen-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=20,
+#             n_events=100000,
+#         ),
+#     ),
+# )
+cpn.add_dataset(
+    name="h_ggf_hmm_powheg",
+    id=14868421,
+    processes=[procs.h_ggf_hmm],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHto2Mu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=21,
+            n_events=200000,
+        ),
+    ),
+)
+
+####################################################################################################
+#
+# h_vbf
+#
+####################################################################################################
+
+cpn.add_dataset(
+    name="h_vbf_hzg_zll_powheg",
+    id=14798046,
+    processes=[procs.h_vbf_hzg_zll],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/VBFHtoZG_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=5,
+            n_events=12000,
+        ),
+        with_dipole_recoil=DatasetInfo(
+            keys=[
+                "/VBFHtoZG_Zto2L_M-125_TuneCP5_withDipoleRecoil_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=4,
+            n_events=96465,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/VBFHtoZG_Zto2L_M-125_CP5TuneUp_withDipoleRecoil_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=5,
+            n_events=98582,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/VBFHtoZG_Zto2L_M-125_CP5TuneDown_withDipoleRecoil_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=5,
+            n_events=96480,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_vbf_hww2l2nu_powheg",
+    id=14849334,
+    processes=[procs.h_vbf_hww2l2nu],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/VBFHto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-jhugen752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=43,
+            n_events=1497840,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/VBFHto2Wto2L2Nu_M-125_TuneCP5Up_13p6TeV_powheg-jhugen752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=56,
+            n_events=1498588,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/VBFHto2Wto2L2Nu_M-125_TuneCP5Down_13p6TeV_powheg-jhugen752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=58,
+            n_events=1497840,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_vbf_hzz4nu_powheg",
+    id=14849329,
+    processes=[procs.h_vbf_hzz4nu],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/VBFHto2Zto4Nu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=30,
+            n_events=500000,
+        ),
+    ),
+)
+# NOTE: this sample includes the *UncorrelatedDecay* tag. No htt dataset without this tag has been found on 07.06.2024
+cpn.add_dataset(
+    name="h_vbf_htt_powheg",
+    id=14926213,
+    processes=[procs.h_vbf_htt],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/VBFHTo2TauUncorrelatedDecay_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=13,
+            n_events=100000,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_vbf_hgg_amcatnlo",
+    id=14885189,
+    processes=[procs.h_vbf_hgg],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/VBFHtoGG_M-125_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=15,
+            n_events=314360,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_vbf_hcc_powheg",
+    id=14853086,
+    processes=[procs.h_vbf_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/VBFHto2C_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=119,
+            n_events=4348092,
+        ),
+    ),
+)
+# cpn.add_dataset(
+#     name="h_vbf_hcc_powheg",
+#     id=14788422,
+#     processes=[procs.h_vbf_hcc],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/VBFHToCC_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-FlatPU0to70_130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=1,
+#             n_events=300000,
+#         ),
+#     ),
+# )
+cpn.add_dataset(
+    name="h_vbf_hbb_powheg",
+    id=14870810,
+    processes=[procs.h_vbf_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/VBFHto2B_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=33,
+            n_events=3330700,
+        ),
+        dipole_recoil_on=DatasetInfo(
+            keys=[
+                "/VBFHto2B_M-125_dipoleRecoilOn_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=31,
+            n_events=948700,
+        ),
+    ),
+)
+
+####################################################################################################
+#
+# zh
+#
+####################################################################################################
+
+cpn.add_dataset(
+    name="zh_zqq_hbb_powheg",
+    id=14805167,
+    processes=[procs.zh_zqq_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZH_Hto2B_Zto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=19,
+            n_events=1144560,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/ZH_Hto2B_Zto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=65,
+            n_events=3177722,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_hzg_powheg",
+    id=14794187,
+    processes=[procs.zh_hzg],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZH_HtoZG_ZtoAll_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=46,
+            n_events=124384,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_zll_hbb_powheg",
+    id=14805378,
+    processes=[procs.zh_zll_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZH_Hto2B_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=34,
+            n_events=599100,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/ZH_Hto2B_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=57,
+            n_events=4339792,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_zll_hcc_powheg",
+    id=14800392,
+    processes=[procs.zh_zll_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZH_Hto2C_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=27,
+            n_events=799380,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/ZH_Hto2C_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=45,
+            n_events=4153800,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_zqq_powheg",
+    id=14849422,
+    processes=[procs.zh_zqq],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZHto2Zto4Nu_Zto2Q_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=70,
+            n_events=497369,
+        ),
+    ),
+)
+# NOTE: this sample includes the *UncorrelatedDecay* tag. No htt dataset without this tag has been found on 07.06.2024
+cpn.add_dataset(
+    name="zh_htt_powheg",
+    id=14927154,
+    processes=[procs.zh_htt],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZHto2TauUncorrelatedDecay_M-125_CP5_13p6TeV_powheg-minnlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=22,
+            n_events=28752,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_hww2l2nu_powheg",
+    id=14918311,
+    processes=[procs.zh_hww2l2nu],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZH_ZtoAll_Hto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-minlo-HZJ-jhugenv752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=53,
+            n_events=963869,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_hzg_zll_powheg",
+    id=14885110,
+    processes=[procs.zh_hzg_zll],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZH_ZtoAll_HtoZGto2LG_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=52,
+            n_events=124660,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/ZH_ZtoAll_HtoZGto2LG_M-125_CP5TuneUp_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=51,
+            n_events=124656,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/ZH_ZtoAll_HtoZGto2LG_M-125_CP5TuneDown_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=38,
+            n_events=124659,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_zqq_hcc_powheg",
+    id=14868489,
+    processes=[procs.zh_zqq_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZH_Hto2C_Zto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=64,
+            n_events=3101694,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_hmm_powheg",
+    id=14863423,
+    processes=[procs.zh_hmm],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZH_Hto2Mu_ZtoAll_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=35,
+            n_events=196974,
+        ),
+    ),
+)
+
+####################################################################################################
+#
+# zh_gg
+#
+####################################################################################################
+
+cpn.add_dataset(
+    name="zh_gg_zqq_hbb_powheg",
+    id=14804331,
+    processes=[procs.zh_gg_zqq_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2B_Zto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=21,
+            n_events=578672,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2B_Zto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=59,
+            n_events=3782022,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_gg_zll_hbb_powheg",
+    id=14803231,
+    processes=[procs.zh_gg_zll_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2B_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=23,
+            n_events=582250,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2B_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=41,
+            n_events=3780820,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_gg_znunu_hbb_powheg",
+    id=14805533,
+    processes=[procs.zh_gg_znunu_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2B_Zto2Nu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=16,
+            n_events=581016,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2B_Zto2Nu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=39,
+            n_events=3784521,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_gg_zll_hcc_powheg",
+    id=14803676,
+    processes=[procs.zh_gg_zll_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2C_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=41,
+            n_events=773402,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2C_Zto2Nu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=38,
+            n_events=3588800,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_gg_znunu_hcc_powheg",
+    id=14846449,
+    processes=[procs.zh_gg_znunu_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2C_Zto2Nu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=29,
+            n_events=797924,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2C_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=39,
+            n_events=3593320,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_gg_zqq_hcc_powheg",
+    id=14853067,
+    processes=[procs.zh_gg_zqq_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2C_Zto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=114,
+            n_events=4391804,
+        ),
+    ),
+)
+
+####################################################################################################
+#
+# WminusH
+#
+####################################################################################################
+
+cpn.add_dataset(
+    name="wmh_hzz4l_powheg",
+    id=14793663,
+    processes=[procs.wmh_hzz4l],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2Zto4L_M-125_TuneCP5_13p6TeV_powheg2-minlo-HWJ-JHUGenV752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=19,
+            n_events=491969,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wmh_wlnu_hbb_powheg",
+    id=14805882,
+    processes=[procs.wmh_wlnu_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2B_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=21,
+            n_events=590044,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2B_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=169,
+            n_events=4399854,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wmh_wqq_hbb_powheg",
+    id=14801338,
+    processes=[procs.wmh_wqq_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2B_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=22,
+            n_events=1147965,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2B_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=223,
+            n_events=3153199,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wmh_wlnu_hcc_powheg",
+    id=14804815,
+    processes=[procs.wmh_wlnu_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2C_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=33,
+            n_events=732400,
+        ),
+    ),
+)
+# NOTE: this sample includes the *UncorrelatedDecay* tag. No htt dataset without this tag has been found on 07.06.2024
+cpn.add_dataset(
+    name="wmh_powheg",
+    id=14926126,
+    processes=[procs.wmh],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusHTo2TauUncorrelatedDecay_M-125_TuneCP5_13p6TeV_powheg-minnlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=12,
+            n_events=30000,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wmh_wqq_hcc_powheg",
+    id=14852474,
+    processes=[procs.wmh_wqq_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2C_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=321,
+            n_events=4357249,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2C_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=147,
+            n_events=4200000,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wmh_wqq_hzz4nu_powheg",
+    id=14849469,
+    processes=[procs.wmh_wqq_hzz4nu],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusHto2Zto4Nu_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=26,
+            n_events=497364,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wmh_hzg_zll_powheg",
+    id=14826664,
+    processes=[procs.wmh_hzg_zll],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusH_HtoZG_WtoAll_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=18,
+            n_events=53961,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/WminusH_HtoZG_WtoAll_Zto2L_M-125_CP5TuneUp_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=12,
+            n_events=70000,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/WminusH_HtoZG_WtoAll_Zto2L_M-125_CP5TuneDown_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=16,
+            n_events=69801,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wmh_hmm_powheg",
+    id=14856644,
+    processes=[procs.wmh_hmm],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2Mu_WtoAll_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=5,
+            n_events=120000,
+        ),
+    ),
+)
+
+####################################################################################################
+#
+# WplusH
+#
+####################################################################################################
+
+cpn.add_dataset(
+    name="wph_htt_powheg",
+    id=14925460,
+    processes=[procs.wph_htt],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusHTo2TauUncorrelatedDecay_M-125_TuneCP5_13p6TeV_powheg-minnlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=14,
+            n_events=30000,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_wqq_hbb_powheg",
+    id=14810156,
+    processes=[procs.wph_wqq_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2B_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=18,
+            n_events=1199214,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2B_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=147,
+            n_events=3179822,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_wlnu_hbb_powheg",
+    id=14804043,
+    processes=[procs.wph_wlnu_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2B_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=22,
+            n_events=565746,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2B_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=159,
+            n_events=4206261,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_wqq_hcc_powheg",
+    id=14852349,
+    processes=[procs.wph_wqq_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2C_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=271,
+            n_events=4369883,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_wlnu_hcc_powheg",
+    id=14795238,
+    processes=[procs.wph_wlnu_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2C_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=62,
+            n_events=754430,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2C_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=155,
+            n_events=4200000,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_hmm_powheg",
+    id=14868497,
+    processes=[procs.wph_hmm],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2Mu_WtoAll_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=26,
+            n_events=118804,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_hzz4l_powheg",
+    id=14810120,
+    processes=[procs.wph_hzz4l],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2Zto4L_M-125_TuneCP5_13p6TeV_powheg2-minlo-HWJ-JHUGenV752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=17,
+            n_events=492605,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_hzg_powheg",
+    id=14798660,
+    processes=[procs.wph_hzg],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusH_HtoZG_WtoAll_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=17,
+            n_events=38162,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/WplusH_HtoZG_WtoAll_Zto2L_M-125_CP5TuneDown_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=24,
+            n_events=39616,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/WplusH_HtoZG_WtoAll_Zto2L_M-125_CP5TuneUp_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=19,
+            n_events=39997,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_hzg_zll_powheg",
+    id=14792521,
+    processes=[procs.wph_hzg_zll],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusH_HtoZG_WtoAll_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=16,
+            n_events=156824,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_wqq_hzz4nu_powheg",
+    id=14849415,
+    processes=[procs.wph_wqq_hzz4nu],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusHto2Zto4Nu_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=28,
+            n_events=495938,
+        ),
+    ),
+)
+
+
+####################################################################################################
+#
+# ttH
+#
+####################################################################################################
+
+# cpn.add_dataset(
+#     name="tth_hzz_powheg",
+#     id=14793299,
+#     processes=[procs.tth_hzz],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/TTH_Hto2Z_M-125_4LFilter_TuneCP5_13p6TeV_powheg2-JHUGenV752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=20,
+#             n_events=96720,
+#         ),
+#     ),
+# )
+cpn.add_dataset(
+    name="tth_hzz_powheg",
+    id=14952169,
+    processes=[procs.tth_hzz],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTH_Hto2Z_4LFilter_M-125_TuneCP5_13p6TeV_powheg-jhugenv752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=7,
+            n_events=95869,
+        ),
+    ),
+)
+# cpn.add_dataset(
+#     name="tth_hnonbb_1j_amcatnlo",
+#     id=14852673,
+#     processes=[procs.tth_hnonbb_1j],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/TTHtoNon2B-1Jets_M-125_TuneCP5_13p6TeV_amcatnloFXFX-madspin-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=165,
+#             n_events=6303497,
+#         ),
+#     ),
+# )
+cpn.add_dataset(
+    name="tth_hnonbb_powheg",
+    id=14849153,
+    processes=[procs.tth_hnonbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTHtoNon2B_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v4/NANOAODSIM",  # noqa
+            ],
+            n_files=46,
+            n_events=3846525,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="tth_hcc_powheg",
+    id=14870558,
+    processes=[procs.tth_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTHto2C_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=37,
+            n_events=3184328,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="tth_hbb_powheg",
+    id=14857767,
+    processes=[procs.tth_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTHto2B_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=45,
+            n_events=3177628,
+        ),
+    ),
+)
+# cpn.add_dataset(
+#     name="tth_hbb_powheg",
+#     id=14870504,
+#     processes=[procs.tth_hbb],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/TTH_Hto2B_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+#             ],
+#             n_files=43,
+#             n_events=2989710,
+#         ),
+#     ),
+# )
+cpn.add_dataset(
+    name="tth_hmm_powheg",
+    id=14868415,
+    processes=[procs.tth_hmm],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTH_Hto2Mu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=28,
+            n_events=197248,
+        ),
+    ),
+)
+
+####################################################################################################
+#
+# ttVH
+#
+####################################################################################################
+
+cpn.add_dataset(
+    name="ttzh_madgraph",
+    id=14861662,
+    processes=[procs.ttz],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTZH_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=43,
+            n_events=798996,
+        ),
+    ),
+)
+
+cpn.add_dataset(
+    name="ttwh_madgraph",
+    id=14860507,
+    processes=[procs.ttwh],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTWH_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=25,
+            n_events=790196,
+        ),
+    ),
+)

--- a/cmsdb/campaigns/run3_2023_preBPix_nano_tau_skim_v2/signal.py
+++ b/cmsdb/campaigns/run3_2023_preBPix_nano_tau_skim_v2/signal.py
@@ -1,0 +1,545 @@
+# coding: utf-8
+
+"""
+CMS datasets from the 2022 post-EE data-taking campaign
+"""
+
+import cmsdb.processes as procs
+from cmsdb.campaigns.run3_2022_preEE_nano_tau_skim_v2 import campaign_run3_2022_preEE_nano_tau_skim_v2 as cpn
+
+cpn.add_dataset(
+    name='glugluhto2tau_uncorrelateddecay_unfiltered',
+    id=11100,
+    is_data=True,
+    processes=[procs.data_glugluhto2tau],
+    keys=['/GluGluHTo2Tau_UncorrelatedDecay_UnFiltered'],
+    n_files=1,
+    n_events=310379,
+)
+
+
+# cpn.add_dataset(
+#     name="signal",
+#     id=11100,
+#     processes=[procs.h_ggf_tautau],
+#     keys=['/GluGluHToTauTau_M125'],
+#     n_files=1,
+#     n_events=295692,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-1000_2HDM-II'],
+#     id=69,
+#     processes=[procs.process_69],
+#     keys=['GluGluHto2Tau_M-1000_2HDM-II'],
+#     n_files=1,
+#     n_events=446596,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-100_2HDM-II'],
+#     id=70,
+#     processes=[procs.h_ggf_tautau],
+#     keys=['/GluGluHto2Tau_M-100_2HDM-II'],
+#     n_files=1,
+#     n_events=449942,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-105_2HDM-II'],
+#     id=71,
+#     processes=[procs.process_71],
+#     keys=['GluGluHto2Tau_M-105_2HDM-II'],
+#     n_files=1,
+#     n_events=448536,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-1100_2HDM-II'],
+#     id=72,
+#     processes=[procs.process_72],
+#     keys=['GluGluHto2Tau_M-1100_2HDM-II'],
+#     n_files=1,
+#     n_events=447987,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-110_2HDM-II'],
+#     id=73,
+#     processes=[procs.process_73],
+#     keys=['GluGluHto2Tau_M-110_2HDM-II'],
+#     n_files=1,
+#     n_events=449958,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-115_2HDM-II'],
+#     id=74,
+#     processes=[procs.process_74],
+#     keys=['GluGluHto2Tau_M-115_2HDM-II'],
+#     n_files=1,
+#     n_events=447160,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-1200_2HDM-II'],
+#     id=75,
+#     processes=[procs.h_ggf_tautau],
+#     keys=['/GluGluHto2Tau_M-1200_2HDM-II'],
+#     n_files=1,
+#     n_events=447983,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-120_2HDM-II'],
+#     id=76,
+#     processes=[procs.process_76],
+#     keys=['GluGluHto2Tau_M-120_2HDM-II'],
+#     n_files=1,
+#     n_events=449175,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-125_2HDM-II'],
+#     id=77,
+#     processes=[procs.h_ggf_tautau],
+#     keys=['GluGluHto2Tau_M-125_2HDM-II'],
+#     n_files=1,
+#     n_events=447825,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-130_2HDM-II'],
+#     id=78,
+#     processes=[procs.process_78],
+#     keys=['GluGluHto2Tau_M-130_2HDM-II'],
+#     n_files=1,
+#     n_events=449968,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-135_2HDM-II'],
+#     id=79,
+#     processes=[procs.process_79],
+#     keys=['GluGluHto2Tau_M-135_2HDM-II'],
+#     n_files=1,
+#     n_events=449970,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-1400_2HDM-II'],
+#     id=80,
+#     processes=[procs.process_80],
+#     keys=['GluGluHto2Tau_M-1400_2HDM-II'],
+#     n_files=1,
+#     n_events=446050,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-140_2HDM-II'],
+#     id=81,
+#     processes=[procs.process_81],
+#     keys=['GluGluHto2Tau_M-140_2HDM-II'],
+#     n_files=1,
+#     n_events=449962,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-1600_2HDM-II'],
+#     id=82,
+#     processes=[procs.process_82],
+#     keys=['GluGluHto2Tau_M-1600_2HDM-II'],
+#     n_files=1,
+#     n_events=448004,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-160_2HDM-II'],
+#     id=83,
+#     processes=[procs.process_83],
+#     keys=['GluGluHto2Tau_M-160_2HDM-II'],
+#     n_files=1,
+#     n_events=449972,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-1800_2HDM-II'],
+#     id=84,
+#     processes=[procs.process_84],
+#     keys=['GluGluHto2Tau_M-1800_2HDM-II'],
+#     n_files=1,
+#     n_events=448684,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-180_2HDM-II'],
+#     id=85,
+#     processes=[procs.process_85],
+#     keys=['GluGluHto2Tau_M-180_2HDM-II'],
+#     n_files=1,
+#     n_events=449279,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-2000_2HDM-II'],
+#     id=86,
+#     processes=[procs.process_86],
+#     keys=['GluGluHto2Tau_M-2000_2HDM-II'],
+#     n_files=1,
+#     n_events=446753,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-200_2HDM-II'],
+#     id=87,
+#     processes=[procs.process_87],
+#     keys=['GluGluHto2Tau_M-200_2HDM-II'],
+#     n_files=1,
+#     n_events=448584,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-2300_2HDM-II'],
+#     id=88,
+#     processes=[procs.process_88],
+#     keys=['GluGluHto2Tau_M-2300_2HDM-II'],
+#     n_files=1,
+#     n_events=449309,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-250_2HDM-II'],
+#     id=89,
+#     processes=[procs.process_89],
+#     keys=['GluGluHto2Tau_M-250_2HDM-II'],
+#     n_files=1,
+#     n_events=448594,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-2600_2HDM-II'],
+#     id=90,
+#     processes=[procs.process_90],
+#     keys=['GluGluHto2Tau_M-2600_2HDM-II'],
+#     n_files=1,
+#     n_events=449332,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-2900_2HDM-II'],
+#     id=91,
+#     processes=[procs.process_91],
+#     keys=['GluGluHto2Tau_M-2900_2HDM-II'],
+#     n_files=1,
+#     n_events=446066,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-300_2HDM-II'],
+#     id=92,
+#     processes=[procs.process_92],
+#     keys=['GluGluHto2Tau_M-300_2HDM-II'],
+#     n_files=1,
+#     n_events=448598,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-3200_2HDM-II'],
+#     id=93,
+#     processes=[procs.process_93],
+#     keys=['GluGluHto2Tau_M-3200_2HDM-II'],
+#     n_files=1,
+#     n_events=449932,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-3500_2HDM-II'],
+#     id=94,
+#     processes=[procs.process_94],
+#     keys=['GluGluHto2Tau_M-3500_2HDM-II'],
+#     n_files=1,
+#     n_events=449908,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-350_2HDM-II'],
+#     id=95,
+#     processes=[procs.process_95],
+#     keys=['GluGluHto2Tau_M-350_2HDM-II'],
+#     n_files=1,
+#     n_events=447891,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-400_2HDM-II'],
+#     id=96,
+#     processes=[procs.process_96],
+#     keys=['GluGluHto2Tau_M-400_2HDM-II'],
+#     n_files=1,
+#     n_events=449301,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-450_2HDM-II'],
+#     id=97,
+#     processes=[procs.process_97],
+#     keys=['GluGluHto2Tau_M-450_2HDM-II'],
+#     n_files=1,
+#     n_events=449992,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-500_2HDM-II'],
+#     id=98,
+#     processes=[procs.process_98],
+#     keys=['GluGluHto2Tau_M-500_2HDM-II'],
+#     n_files=1,
+#     n_events=449988,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-600_2HDM-II'],
+#     id=99,
+#     processes=[procs.process_99],
+#     keys=['GluGluHto2Tau_M-600_2HDM-II'],
+#     n_files=1,
+#     n_events=449300,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-60_2HDM-II'],
+#     id=100,
+#     processes=[procs.process_100],
+#     keys=['GluGluHto2Tau_M-60_2HDM-II'],
+#     n_files=1,
+#     n_events=447803,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-65_2HDM-II'],
+#     id=101,
+#     processes=[procs.process_101],
+#     keys=['GluGluHto2Tau_M-65_2HDM-II'],
+#     n_files=1,
+#     n_events=448504,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-700_2HDM-II'],
+#     id=102,
+#     processes=[procs.process_102],
+#     keys=['GluGluHto2Tau_M-700_2HDM-II'],
+#     n_files=1,
+#     n_events=449994,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-70_2HDM-II'],
+#     id=103,
+#     processes=[procs.process_103],
+#     keys=['GluGluHto2Tau_M-70_2HDM-II'],
+#     n_files=1,
+#     n_events=448500,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-75_2HDM-II'],
+#     id=104,
+#     processes=[procs.process_104],
+#     keys=['GluGluHto2Tau_M-75_2HDM-II'],
+#     n_files=1,
+#     n_events=449940,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-800_2HDM-II'],
+#     id=105,
+#     processes=[procs.process_105],
+#     keys=['GluGluHto2Tau_M-800_2HDM-II'],
+#     n_files=1,
+#     n_events=448646,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-80_2HDM-II'],
+#     id=106,
+#     processes=[procs.process_106],
+#     keys=['GluGluHto2Tau_M-80_2HDM-II'],
+#     n_files=1,
+#     n_events=448532,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-85_2HDM-II'],
+#     id=107,
+#     processes=[procs.process_107],
+#     keys=['GluGluHto2Tau_M-85_2HDM-II'],
+#     n_files=1,
+#     n_events=448516,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-900_2HDM-II'],
+#     id=108,
+#     processes=[procs.process_108],
+#     keys=['GluGluHto2Tau_M-900_2HDM-II'],
+#     n_files=1,
+#     n_events=448622,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-90_2HDM-II'],
+#     id=109,
+#     processes=[procs.process_109],
+#     keys=['GluGluHto2Tau_M-90_2HDM-II'],
+#     n_files=1,
+#     n_events=448516,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+
+# cpn.add_dataset(
+#     name=['GluGluHto2Tau_M-95_2HDM-II'],
+#     id=110,
+#     processes=[procs.process_110],
+#     keys=['GluGluHto2Tau_M-95_2HDM-II'],
+#     n_files=1,
+#     n_events=447820,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )
+# cpn.add_dataset(
+#     name=['VBFHToTauTau_M125'],
+#     id=370,
+#     processes=[procs.process_370],
+#     keys=['VBFHToTauTau_M125'],
+#     n_files=1,
+#     n_events=298955,
+#     aux={
+#         "require_triggers"  : ["IsoMu24",]
+#     },
+# )

--- a/cmsdb/campaigns/run3_2023_preBPix_nano_tau_skim_v2/top.py
+++ b/cmsdb/campaigns/run3_2023_preBPix_nano_tau_skim_v2/top.py
@@ -15,7 +15,7 @@ cpn.add_dataset(
     processes=[procs.st_tchannel_t],
     keys=['/ST_t_channel_top_4f_InclusiveDecays'],
     n_files=6,
-    n_events=2242994,
+    n_events=5908000,
     aux=None
 )
 
@@ -26,7 +26,7 @@ cpn.add_dataset(
     processes=[procs.st_tchannel_tbar],
     keys=['/ST_t_channel_antitop_4f_InclusiveDecays'],
     n_files=3,
-    n_events=1106961,
+    n_events=2878000,
     aux=None
 )
 
@@ -36,7 +36,7 @@ cpn.add_dataset(
     processes=[procs.st_twchannel_t_sl],
     keys=['/ST_tW_top_LNu2Q'],
     n_files=18,
-    n_events=7590122,
+    n_events=9650268,
     aux=None
 )
 
@@ -46,7 +46,7 @@ cpn.add_dataset(
     processes=[procs.st_twchannel_t_dl],
     keys=['/ST_tW_top_2L2Nu'],
     n_files=10,
-    n_events=4454589,
+    n_events=4985000,
     aux=None
 )
 
@@ -57,7 +57,7 @@ cpn.add_dataset(
     processes=[procs.st_twchannel_t_fh],
     keys=['/ST_tW_top_4Q'],
     n_files=9,
-    n_events=3033233,
+    n_events=7919000,
     aux=None
 )
 
@@ -67,7 +67,7 @@ cpn.add_dataset(
     processes=[procs.st_twchannel_tbar_sl],
     keys=['/ST_tW_antitop_LNu2Q'],
     n_files=17,
-    n_events=7488647,
+    n_events=9519385,
     aux=None
 )
 
@@ -77,7 +77,7 @@ cpn.add_dataset(
     processes=[procs.st_twchannel_tbar_dl],
     keys=['/ST_tW_antitop_2L2Nu'],
     n_files=10,
-    n_events=4385641,
+    n_events=4907000,
     aux=None
 )
 
@@ -87,7 +87,7 @@ cpn.add_dataset(
     processes=[procs.st_twchannel_tbar_fh],
     keys=['/ST_tW_antitop_4Q'],
     n_files=9,
-    n_events=3054459,
+    n_events=7970000,
     aux=None
 )
 cpn.add_dataset(
@@ -96,7 +96,7 @@ cpn.add_dataset(
     processes=[procs.st_schannel_t_lep],
     keys=['/ST_s_channel_top_4f_leptonDecays'],
     n_files=4,
-    n_events=1446621,
+    n_events=2588000,
 )
 cpn.add_dataset(
     name="st_schannel_tbar_lep",
@@ -104,7 +104,7 @@ cpn.add_dataset(
     processes=[procs.st_schannel_tbar_lep],
     keys=['/ST_s_channel_antitop_4f_leptonDecays'],
     n_files=2,
-    n_events=895742,
+    n_events=1600000,
 )
 ### TT SAMPLES ###
 
@@ -114,7 +114,7 @@ cpn.add_dataset(
     processes=[procs.tt_sl],
     keys=['/TTtoLNu2Q'],
     n_files= 318,
-    n_events= 125809500,
+    n_events= 152653000,
     aux=None
 )
 
@@ -124,7 +124,7 @@ cpn.add_dataset(
     processes=[procs.tt_dl],
     keys=['/TTto2L2Nu'],
     n_files=111,
-    n_events=44488239,
+    n_events=48104000,
     aux=None
 )
 
@@ -134,7 +134,7 @@ cpn.add_dataset(
     processes=[procs.tt_fh],
     keys=['/TTto4Q'],
     n_files=142,
-    n_events=46072091,
+    n_events=104963000,
     aux=None
 )
 

--- a/cmsdb/campaigns/run3_2023_preBPix_nano_tau_skim_v2/top.py
+++ b/cmsdb/campaigns/run3_2023_preBPix_nano_tau_skim_v2/top.py
@@ -1,0 +1,178 @@
+
+"""
+Top quark datasets for the 2022 pre-EE data-taking campaign
+"""
+
+import cmsdb.processes as procs
+from cmsdb.campaigns.run3_2023_preBPix_nano_tau_skim_v2  import campaign_run3_2023_preBPix_nano_tau_skim_v2 as cpn
+
+
+### SINGLE TOP ###
+#TBbarQ
+cpn.add_dataset(
+    name='st_tchannel_t',
+    id=22120118,
+    processes=[procs.st_tchannel_t],
+    keys=['/ST_t_channel_top_4f_InclusiveDecays'],
+    n_files=6,
+    n_events=2242994,
+    aux=None
+)
+
+#TbarBQ_t
+cpn.add_dataset(
+    name='st_tchannel_tbar',
+    id=22120119,
+    processes=[procs.st_tchannel_tbar],
+    keys=['/ST_t_channel_antitop_4f_InclusiveDecays'],
+    n_files=3,
+    n_events=1106961,
+    aux=None
+)
+
+cpn.add_dataset(
+    name='st_twchannel_t_sl',
+    id=22120120,
+    processes=[procs.st_twchannel_t_sl],
+    keys=['/ST_tW_top_LNu2Q'],
+    n_files=18,
+    n_events=7590122,
+    aux=None
+)
+
+cpn.add_dataset(
+    name='st_twchannel_t_dl',
+    id=22120121,
+    processes=[procs.st_twchannel_t_dl],
+    keys=['/ST_tW_top_2L2Nu'],
+    n_files=10,
+    n_events=4454589,
+    aux=None
+)
+
+
+cpn.add_dataset(
+    name='st_twchannel_t_fh',
+    id=22120122,
+    processes=[procs.st_twchannel_t_fh],
+    keys=['/ST_tW_top_4Q'],
+    n_files=9,
+    n_events=3033233,
+    aux=None
+)
+
+cpn.add_dataset(
+    name='st_twchannel_tbar_sl',
+    id=22120123,
+    processes=[procs.st_twchannel_tbar_sl],
+    keys=['/ST_tW_antitop_LNu2Q'],
+    n_files=17,
+    n_events=7488647,
+    aux=None
+)
+
+cpn.add_dataset(
+    name='st_twchannel_tbar_dl',
+    id=22120124,
+    processes=[procs.st_twchannel_tbar_dl],
+    keys=['/ST_tW_antitop_2L2Nu'],
+    n_files=10,
+    n_events=4385641,
+    aux=None
+)
+
+cpn.add_dataset(
+    name='st_twchannel_tbar_fh',
+    id=22120125,
+    processes=[procs.st_twchannel_tbar_fh],
+    keys=['/ST_tW_antitop_4Q'],
+    n_files=9,
+    n_events=3054459,
+    aux=None
+)
+cpn.add_dataset(
+    name="st_schannel_t_lep",
+    id=22120126,
+    processes=[procs.st_schannel_t_lep],
+    keys=['/ST_s_channel_top_4f_leptonDecays'],
+    n_files=4,
+    n_events=1446621,
+)
+cpn.add_dataset(
+    name="st_schannel_tbar_lep",
+    id=22120127,
+    processes=[procs.st_schannel_tbar_lep],
+    keys=['/ST_s_channel_antitop_4f_leptonDecays'],
+    n_files=2,
+    n_events=895742,
+)
+### TT SAMPLES ###
+
+cpn.add_dataset(
+    name='tt_sl',
+    id=22120115,
+    processes=[procs.tt_sl],
+    keys=['/TTtoLNu2Q'],
+    n_files= 318,
+    n_events= 125809500,
+    aux=None
+)
+
+cpn.add_dataset(
+    name='tt_dl',
+    id=22120116,
+    processes=[procs.tt_dl],
+    keys=['/TTto2L2Nu'],
+    n_files=111,
+    n_events=44488239,
+    aux=None
+)
+
+cpn.add_dataset(
+    name='tt_fh',
+    id=22120117,
+    processes=[procs.tt_fh],
+    keys=['/TTto4Q'],
+    n_files=142,
+    n_events=46072091,
+    aux=None
+)
+
+
+
+# cpn.add_dataset(
+#     name="dataset_40",
+#     id=40,
+#     processes=[procs.process_40],
+#     keys=['ST_t_channel_antitop_4f_InclusiveDecays'],
+#     n_files=2,
+#     n_events=1325389.0,
+# )
+
+
+
+# cpn.add_dataset(
+#     name="dataset_70",
+#     id=70,
+#     processes=[procs.process_70],
+#     keys=['TT'],
+#     n_files=14,
+#     n_events=7398738.0,
+# )
+
+# cpn.add_dataset(
+#     name="dataset_71",
+#     id=71,
+#     processes=[procs.process_71],
+#     keys=['TT_ext1'],
+#     n_files=13,
+#     n_events=7301650.0,
+# )
+
+
+
+
+
+
+
+

--- a/scripts/read_prodReport_nano.py
+++ b/scripts/read_prodReport_nano.py
@@ -1,0 +1,22 @@
+# Quick script to read the number of events and files from prodReport_nano.json produced with HLepRare group 
+# python3 read_prodReport_nano.py --dir TTto4Q 
+
+import json
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument( '--dir', help='path to the dataset directory where the prodReport_nano.json', default="Muon0_Run2023D_v1")
+parser.add_argument( '--eos', help='path to the dataset directory where the prodReport_nano.json', default="/eos/cms/store/group/phys_higgs/HLepRare/skim_2024_v2/Run3_2023BPix")
+args = parser.parse_args()
+
+full_path = args.eos +"/" + args.dir + "/prodReport_nano.json"
+#full_path = "prodReport_nano.json"
+
+with open(full_path, "r") as f:
+    prod_dict = json.load(f)
+
+files = prod_dict["outputs"].keys()
+n_files = len(files)
+n_events = sum([prod_dict["outputs"][x]["n_selected"] for x in prod_dict["outputs"].keys()])
+print( args.dir ,":\n n_files = ", n_files, "\n n_events = ", n_events )
+

--- a/scripts/read_prodReport_nano.py
+++ b/scripts/read_prodReport_nano.py
@@ -6,7 +6,7 @@ import argparse
 
 parser = argparse.ArgumentParser()
 parser.add_argument( '--dir', help='path to the dataset directory where the prodReport_nano.json', default="Muon0_Run2023D_v1")
-parser.add_argument( '--eos', help='path to the eos HLepRare directory', default="/eos/cms/store/group/phys_higgs/HLepRare/skim_2024_v2/Run3_2023BPix")
+parser.add_argument( '--eos', help='path to the eos HLepRare directory', default="/eos/cms/store/group/phys_higgs/HLepRare/skim_2024_v2/Run3_2023")
 args = parser.parse_args()
 
 full_path = args.eos +"/" + args.dir + "/prodReport_nano.json"
@@ -16,6 +16,6 @@ with open(full_path, "r") as f:
 
 files = prod_dict["outputs"].keys()
 n_files = len(files)
-n_events = sum([prod_dict["outputs"][x]["n_selected"] for x in prod_dict["outputs"].keys()])
+n_events = sum([(prod_dict["outputs"][x]["n_selected"] + prod_dict["outputs"][x]["n_not_selected"])for x in prod_dict["outputs"].keys()])
 print( args.dir ,":\n n_files = ", n_files, "\n n_events = ", n_events )
 

--- a/scripts/read_prodReport_nano.py
+++ b/scripts/read_prodReport_nano.py
@@ -6,11 +6,10 @@ import argparse
 
 parser = argparse.ArgumentParser()
 parser.add_argument( '--dir', help='path to the dataset directory where the prodReport_nano.json', default="Muon0_Run2023D_v1")
-parser.add_argument( '--eos', help='path to the dataset directory where the prodReport_nano.json', default="/eos/cms/store/group/phys_higgs/HLepRare/skim_2024_v2/Run3_2023BPix")
+parser.add_argument( '--eos', help='path to the eos HLepRare directory', default="/eos/cms/store/group/phys_higgs/HLepRare/skim_2024_v2/Run3_2023BPix")
 args = parser.parse_args()
 
 full_path = args.eos +"/" + args.dir + "/prodReport_nano.json"
-#full_path = "prodReport_nano.json"
 
 with open(full_path, "r") as f:
     prod_dict = json.load(f)

--- a/scripts/read_prodReport_nano.py
+++ b/scripts/read_prodReport_nano.py
@@ -6,7 +6,7 @@ import argparse
 
 parser = argparse.ArgumentParser()
 parser.add_argument( '--dir', help='path to the dataset directory where the prodReport_nano.json', default="Muon0_Run2023D_v1")
-parser.add_argument( '--eos', help='path to the eos HLepRare directory', default="/eos/cms/store/group/phys_higgs/HLepRare/skim_2024_v2/Run3_2023")
+parser.add_argument( '--eos', help='path to the eos HLepRare directory', default="/eos/cms/store/group/phys_higgs/HLepRare/skim_2024_v2/Run3_2023BPix")
 args = parser.parse_args()
 
 full_path = args.eos +"/" + args.dir + "/prodReport_nano.json"
@@ -16,6 +16,6 @@ with open(full_path, "r") as f:
 
 files = prod_dict["outputs"].keys()
 n_files = len(files)
-n_events = sum([(prod_dict["outputs"][x]["n_selected"] + prod_dict["outputs"][x]["n_not_selected"])for x in prod_dict["outputs"].keys()])
+n_events = sum([(prod_dict["outputs"][x]["n_selected"] + prod_dict["outputs"][x]["n_not_selected"]) for x in prod_dict["outputs"].keys()])
 print( args.dir ,":\n n_files = ", n_files, "\n n_events = ", n_events )
 


### PR DESCRIPTION
The number of files and events is estimated from `prodReport_nano.json` with  a short scripts included in this PR `scripts/read_prodReport_nano.py` 
Note that the data list looks a bit different from 2022 year for example, there is some explanation  here https://twiki.cern.ch/twiki/bin/viewauth/CMS/PdmVRun3Analysis#DATA_AN1